### PR TITLE
JBPM-8320: Redesign of ProcessRuntime API

### DIFF
--- a/drools-quarkus-example/pom.xml
+++ b/drools-quarkus-example/pom.xml
@@ -24,6 +24,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <submarine.version>8.0.0-SNAPSHOT</submarine.version>
         <generateModel>YES</generateModel>
+        <generateProcessModel>NO</generateProcessModel>
     </properties>
 
 

--- a/jbpm-quarkus-example/src/main/resources/workitem-handlers.properties
+++ b/jbpm-quarkus-example/src/main/resources/workitem-handlers.properties
@@ -1,0 +1,1 @@
+Service Task = test

--- a/jbpm-springboot-example/pom.xml
+++ b/jbpm-springboot-example/pom.xml
@@ -22,6 +22,7 @@
     <swagger.version>1.5.21</swagger.version>
     <cxf.version>3.2.6</cxf.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
+    <dependencyInjection>false</dependencyInjection>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
fix examples: disable dependencyInjection for SpringBoot and disable generateProcessModel for Drools