### PR TITLE
Add maven version required 3.5.3+ to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,30 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+        <!-- need at least maven 3.5.3, fail fast with actionable error rather than obscure errors like [ Error injecting: private org.eclipse.aether.spi.log.Logger org.apache.maven.repository.internal.DefaultVersionRangeResolver.logger ] -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M2</version>
+          <executions>
+            <execution>
+              <id>enforce-maven</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>3.5.3+</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+    </plugins>
+    
   </build>
 
 </project>


### PR DESCRIPTION
Per https://github.com/kiegroup/kogito-examples/issues/51, new developer onboarding quality-of-life improvement.  Fast-fail if they aren't using Maven 3.5.3 or higher, otherwise get obscure errors requiring research later downstream.