### PR TITLE
Add OpenShift test coverage for onboarding example

### DIFF
--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
@@ -119,6 +119,8 @@ public class Deployer {
         s2iConfigBuilder.setOutput(resultImageStreamName);
         s2iConfigBuilder.gitSource(assetsUrl.toExternalForm());
         s2iConfigBuilder.sti().fromImageStream(project.getName(), s2iImageStreamName, s2iImageStreamTag);
+        s2iConfigBuilder.addMemoryResource().setRequests("6Gi").setLimits("6Gi");
+        s2iConfigBuilder.addCPUResource().setRequests("2").setLimits("2");
 
         if (gitContextDir != null && !gitContextDir.isEmpty()) {
             s2iConfigBuilder.gitContextDir(gitContextDir);

--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
@@ -16,7 +16,13 @@
 package org.kogito.examples.openshift.deployment;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import cz.xtf.builder.builders.BuildConfigBuilder;
 import cz.xtf.builder.builders.ImageStreamBuilder;
@@ -44,23 +50,39 @@ public class Deployer {
         return deployKaasUsingS2iAndWait(project, assetsUrl, null, s2iBuildImageTag, s2iRuntimeImageTag);
     }
 
+    public static HttpDeployment deployKaasUsingS2iAndWait(Project project, URL assetsUrl, String gitContextDir, String s2iBuildImageTag, String s2iRuntimeImageTag) {
+        return deployKaasUsingS2iAndWait(project, "kaas", assetsUrl, gitContextDir, s2iBuildImageTag, s2iRuntimeImageTag, new HashMap<>(), new HashMap<>());
+    }
+
     /**
      * Deploy KaaS application into the project using S2I and wait until application starts.
      *
      * @param project Project where the application will be deployed to.
+     * @param applicationName Name of the deployed application.
      * @param assetsUrl URL pointing to the GIT repo containing Kie assets.
      * @param gitContextDir Context directory of GIT repo containing Kie assets.
      * @param s2iBuildImageTag Image tag pointing to image used to build KaaS application from source code.
      * @param s2iRuntimeImageTag Image tag pointing to image used as a base for KaaS runtime application.
+     * @param envVariables Environment variables for running application.
+     * @param serviceLabels Service labels applied to deployed service.
      * @return Deployment object containing reference to the deployed application URL.
      */
-    public static HttpDeployment deployKaasUsingS2iAndWait(Project project, URL assetsUrl, String gitContextDir, String s2iBuildImageTag, String s2iRuntimeImageTag) {
+    public static HttpDeployment deployKaasUsingS2iAndWait(Project project, String applicationName, URL assetsUrl, String gitContextDir, String s2iBuildImageTag, String s2iRuntimeImageTag, Map<String, String> envVariables, Map<String, String> serviceLabels) {
         OpenShiftBinary masterBinary = OpenShifts.masterBinary(project.getName());
 
-        String s2iResultImageStreamName = buildKaasS2iApplication(project, assetsUrl, gitContextDir, s2iBuildImageTag);
-        String runtimeImageBuildName = buildKaasS2iRuntimeImage(project, s2iResultImageStreamName, s2iRuntimeImageTag);
+        String s2iResultImageStreamName = buildKaasS2iApplication(project, applicationName, assetsUrl, gitContextDir, s2iBuildImageTag);
+        String runtimeImageBuildName = buildKaasS2iRuntimeImage(project, applicationName, s2iResultImageStreamName, s2iRuntimeImageTag);
 
-        masterBinary.execute("new-app", runtimeImageBuildName + ":latest");
+        List<String> newAppCommand = new ArrayList<>(Arrays.asList("new-app", runtimeImageBuildName + ":latest"));
+        if (!envVariables.isEmpty()) {
+            newAppCommand.add("-e");
+            newAppCommand.add(getParameterKeyValueString(envVariables));
+        }
+        if (!serviceLabels.isEmpty()) {
+            newAppCommand.add("-l");
+            newAppCommand.add(getParameterKeyValueString(serviceLabels));
+        }
+        masterBinary.execute(newAppCommand.toArray(new String[0]));
         project.getMaster().waiters().areExactlyNPodsRunning(1, runtimeImageBuildName).timeout(TimeUnit.MINUTES, 1L).waitFor();
 
         masterBinary.execute("expose", "svc/" + runtimeImageBuildName);
@@ -78,16 +100,17 @@ public class Deployer {
      * Build the KaaS application image and push it to an image stream.
      *
      * @param project
+     * @param applicationName Name of the application to be built.
      * @param assetsUrl URL pointing to the GIT repo containing Kie assets.
      * @param gitContextDir Context directory of GIT repo containing Kie assets.
      * @param s2iBuildImageTag Image tag pointing to image used to build KaaS application from source code.
      * @return Name of the image stream containing application image.
      */
-    private static String buildKaasS2iApplication(Project project, URL assetsUrl, String gitContextDir, String s2iBuildImageTag) {
-        String s2iImageStreamName = "kaas-builder-s2i-image";
+    private static String buildKaasS2iApplication(Project project, String applicationName, URL assetsUrl, String gitContextDir, String s2iBuildImageTag) {
+        String s2iImageStreamName = applicationName + "-builder-s2i-image";
         String s2iImageStreamTag = "1.0";
-        String buildName = "kaas-s2i-build";
-        String resultImageStreamName = "kaas-s2i";
+        String buildName = applicationName + "-s2i-build";
+        String resultImageStreamName = applicationName + "-s2i";
 
         createInsecureImageStream(project, s2iImageStreamName, s2iImageStreamTag, s2iBuildImageTag);
         createEmptyImageStream(project, resultImageStreamName);
@@ -111,15 +134,16 @@ public class Deployer {
      * Build runtime image of the KaaS application and push it to an image stream.
      *
      * @param project
+     * @param applicationName Name of the application to be built.
      * @param s2iResultImageStreamName Image stream name containing KaaS application created by S2I build.
      * @param s2iRuntimeImageTag Image tag pointing to image used as a base for KaaS runtime application.
      * @return Name of the image stream containing runtime image.
      */
-    private static String buildKaasS2iRuntimeImage(Project project, String s2iResultImageStreamName, String s2iRuntimeImageTag) {
-        String finalImageStreamName = "kaas-builder-image";
+    private static String buildKaasS2iRuntimeImage(Project project, String applicationName, String s2iResultImageStreamName, String s2iRuntimeImageTag) {
+        String finalImageStreamName = applicationName + "-builder-image";
         String finalImageStreamTag = "1.0";
-        String buildName = "kaas-runtime-build";
-        String resultImageStreamName = "kaas-runtime";
+        String buildName = applicationName + "-runtime-build";
+        String resultImageStreamName = applicationName + "-runtime";
 
         createInsecureImageStream(project, finalImageStreamName, finalImageStreamTag, s2iRuntimeImageTag);
         createEmptyImageStream(project, resultImageStreamName);
@@ -196,5 +220,15 @@ public class Deployer {
     private static void createEmptyImageStream(Project project, String name) {
         ImageStream imageStream = new ImageStreamBuilder(name).build();
         project.getMaster().createImageStream(imageStream);
+    }
+
+    /**
+     * Returns String containing parameters prepared for usage with OC client, in for of parameter1=value1,parameter=value2...
+     *
+     * @param parameters
+     * @return
+     */
+    private static String getParameterKeyValueString(Map<String, String> parameters) {
+        return parameters.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(","));
     }
 }

--- a/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleManualBuildIntegrationTest.java
+++ b/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleManualBuildIntegrationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kogito.examples.openshift;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import cz.xtf.core.http.Https;
+import cz.xtf.core.openshift.OpenShiftBinary;
+import cz.xtf.core.openshift.OpenShifts;
+import org.junit.jupiter.api.BeforeAll;
+import org.kogito.examples.openshift.deployment.Deployer;
+import org.kogito.examples.openshift.deployment.HttpDeployment;
+
+public class OnboardingQuarkusExampleManualBuildIntegrationTest extends OnboardingQuarkusExampleTestBase {
+
+    private static HttpDeployment kogitoDeployment;
+
+    @BeforeAll
+    public static void setUpManualBuild() throws MalformedURLException {
+        Map<String, String> payrollServiceLabels = new HashMap<>();
+        payrollServiceLabels.put("taxRate", "process");
+        payrollServiceLabels.put("vacationDays", "process");
+        payrollServiceLabels.put("paymentDate", "process");
+
+        Map<String, String> hrServiceLabels = new HashMap<>();
+        hrServiceLabels.put("department", "process");
+        hrServiceLabels.put("id", "process");
+        hrServiceLabels.put("employeeValidation", "process");
+
+        // Add view rights for default role so onboarding service can discover other services.
+        OpenShiftBinary masterBinary = OpenShifts.masterBinary(project.getName());
+        masterBinary.execute("policy", "add-role-to-user", "view", "-z", "default");
+
+        kogitoDeployment = Deployer.deployKaasUsingS2iAndWait(project, ONBOARDING_DEPLOYMENT_NAME, new URL(ASSETS_URL), ONBOARDING_GIT_CONTEXT_DIR, TestConfig.getKaasS2iQuarkusBuilderImage(), TestConfig.getKaasQuarkusRuntimeImage(), Collections.singletonMap("NAMESPACE", project.getName()), new HashMap<>());
+        Deployer.deployKaasUsingS2iAndWait(project, PAYROLL_DEPLOYMENT_NAME, new URL(ASSETS_URL), PAYROLL_GIT_CONTEXT_DIR, TestConfig.getKaasS2iQuarkusBuilderImage(), TestConfig.getKaasQuarkusRuntimeImage(), new HashMap<>(), payrollServiceLabels);
+        Deployer.deployKaasUsingS2iAndWait(project, HR_DEPLOYMENT_NAME, new URL(ASSETS_URL), HR_GIT_CONTEXT_DIR, TestConfig.getKaasS2iQuarkusBuilderImage(), TestConfig.getKaasQuarkusRuntimeImage(), new HashMap<>(), hrServiceLabels);
+    }
+
+    @Override
+    protected HttpDeployment getKogitoDeployment() {
+        return kogitoDeployment;
+    }
+}

--- a/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleTestBase.java
+++ b/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleTestBase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kogito.examples.openshift;
+
+import java.net.MalformedURLException;
+
+import io.restassured.RestAssured;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kogito.examples.openshift.deployment.HttpDeployment;
+
+public abstract class OnboardingQuarkusExampleTestBase {
+
+    protected static Project project;
+
+    protected static final String ASSETS_URL = "https://github.com/kiegroup/kogito-examples";
+    protected static final String ONBOARDING_GIT_CONTEXT_DIR = "onboarding-example/onboarding";
+    protected static final String PAYROLL_GIT_CONTEXT_DIR = "onboarding-example/payroll";
+    protected static final String HR_GIT_CONTEXT_DIR = "onboarding-example/hr";
+
+    protected static final String ONBOARDING_DEPLOYMENT_NAME = "onboarding";
+    protected static final String PAYROLL_DEPLOYMENT_NAME = "payroll";
+    protected static final String HR_DEPLOYMENT_NAME = "hr";
+
+    @BeforeAll
+    public static void setUpProject() throws MalformedURLException {
+        String randomProjectName = RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+        project = Project.create("onboarding-example-" + randomProjectName);
+    }
+
+    @AfterAll
+    public static void tearDownProject() {
+        project.delete();
+    }
+
+    protected abstract HttpDeployment getKogitoDeployment();
+
+    @Test
+    public void testOnboarding() {
+        RestAssured.given()
+            .header("Content-Type", "application/json")
+            .body("{\"employee\" : {\"firstName\" : \"Mark\", \"lastName\" : \"Test\", \"personalId\" : \"xxx-yy-zzz\", \"birthDate\" : \"1995-12-10T14:50:12.123+02:00\", \"address\" : {\"country\" : \"US\", \"city\" : \"Boston\", \"street\" : \"any street 3\", \"zipCode\" : \"10001\"}}}")
+        .when()
+            .post(getKogitoDeployment().getRouteUrl().toExternalForm() + "/onboarding")
+        .then()
+            .statusCode(200)
+            .assertThat().body(StringContains.containsString("\"manager\":\"John Doe\""), StringContains.containsString("\"taxRate\":35.0"));
+    }
+}


### PR DESCRIPTION
@ricardozanini @radtriste Can you please take a look?
Covering just manual installation using OC client, Operator installation will be covered when service label support is added (https://issues.jboss.org/browse/KOGITO-82).