### PR TITLE
Force kubernetes client to use last version

### DIFF
--- a/openshift-example-tests/.gitignore
+++ b/openshift-example-tests/.gitignore
@@ -1,4 +1,5 @@
 bin/
+tmp/
 /target
 /local
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
   <properties>
     <surefire.forkCount>1</surefire.forkCount>
     <alphanetworkCompilerEnabled>false</alphanetworkCompilerEnabled>
+    <!-- Force kubernetes client version as long as cz-xtf library did not integrate it, due to bug https://github.com/fabric8io/kubernetes-client/issues/1631 -->
+    <version.kubernetes-client>4.4.0</version.kubernetes-client>
   </properties>
 
   <repositories>


### PR DESCRIPTION
beacuse of a bug on project creation in Openshift 4:
https://github.com/fabric8io/kubernetes-client/issues/1631

set tmp/ folder in .gitignore as it can be created by cz-xtf library if
no oc binary path given and is not deleted ...