### PR TITLE
Allow optional MAVEN_MIRROR_URL configuration

### DIFF
--- a/openshift-example-tests/README.md
+++ b/openshift-example-tests/README.md
@@ -16,5 +16,6 @@ To properly configure OpenShift and related images user needs to specify these p
 * image.kaas.quarkus.runtime - Tag for Quarkus runtime image, for example built from https://github.com/kiegroup/kogito-cloud/tree/master/s2i/kaas-quarkus-centos
 * image.kaas.springboot.builder.s2i - Tag for S2I image, for example buil from https://github.com/kiegroup/kogito-cloud/tree/master/s2i/kaas-springboot-centos-s2i
 * image.kaas.springboot.runtime - Tag for runtime image, for example built from https://github.com/kiegroup/kogito-cloud/tree/master/s2i/kaas-springboot-centos
+* maven.mirror.url - URL for Maven mirror. This mirror is used in S2I build.
 
 These properties need to be set as system property or they can be placed in test.properties file (with appropriate values). test.properties file can be placed next to pom.xml of the parent directory. It is added to .gitignore.

--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/TestConfig.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/TestConfig.java
@@ -15,6 +15,8 @@
 
 package org.kogito.examples.openshift;
 
+import java.util.Optional;
+
 import cz.xtf.core.config.XTFConfig;
 
 public class TestConfig {
@@ -23,6 +25,8 @@ public class TestConfig {
     private static final String IMAGE_KAAS_QUARKUS_RUNTIME = "image.kaas.quarkus.runtime";
     private static final String IMAGE_KAAS_SPRINGBOOT_BUILDER_S2I = "image.kaas.springboot.builder.s2i";
     private static final String IMAGE_KAAS_SPRINGBOOT_RUNTIME = "image.kaas.springboot.runtime";
+
+    private static final String MAVEN_MIRROR_URL = "maven.mirror.url";
 
     public static String getKaasS2iQuarkusBuilderImage() {
         return getMandatoryProperty(IMAGE_KAAS_QUARKUS_BUILDER_S2I);
@@ -40,11 +44,23 @@ public class TestConfig {
         return getMandatoryProperty(IMAGE_KAAS_SPRINGBOOT_RUNTIME);
     }
 
+    public static Optional<String> getMavenMirrorUrl() {
+        return getOptionalProperty(MAVEN_MIRROR_URL);
+    }
+
     private static String getMandatoryProperty(String propertyName) {
         String propertyValue = XTFConfig.get(propertyName);
         if (propertyValue == null || propertyValue.isEmpty()) {
             throw new RuntimeException("Required property with name " + propertyName + " is not set.");
         }
         return propertyValue;
+    }
+
+    private static Optional<String> getOptionalProperty(String propertyName) {
+        String propertyValue = XTFConfig.get(propertyName);
+        if (propertyValue == null || propertyValue.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(propertyValue);
     }
 }

--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/deployment/Deployer.java
@@ -34,6 +34,7 @@ import io.fabric8.openshift.api.model.ImageSourceBuilder;
 import io.fabric8.openshift.api.model.ImageSourcePath;
 import io.fabric8.openshift.api.model.ImageStream;
 import org.kogito.examples.openshift.Project;
+import org.kogito.examples.openshift.TestConfig;
 
 public class Deployer {
 
@@ -125,6 +126,8 @@ public class Deployer {
         if (gitContextDir != null && !gitContextDir.isEmpty()) {
             s2iConfigBuilder.gitContextDir(gitContextDir);
         }
+
+        TestConfig.getMavenMirrorUrl().ifPresent(mavenMirrorUrl -> s2iConfigBuilder.sti().addEnvVariable("MAVEN_MIRROR_URL", mavenMirrorUrl));
 
         project.getMaster().createBuildConfig(s2iConfigBuilder.build());
         project.getMaster().startBuild(buildName);

--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/operator/model/Build.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/operator/model/Build.java
@@ -15,6 +15,10 @@
 
 package org.kogito.examples.openshift.operator.model;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -25,6 +29,7 @@ public class Build {
 
     private Boolean incremental;
     private GitSource gitSource;
+    private List<Env> env = new ArrayList<>();
 
     public Boolean getIncremental() {
         return incremental;
@@ -40,5 +45,21 @@ public class Build {
 
     public void setGitSource(GitSource gitSource) {
         this.gitSource = gitSource;
+    }
+
+    public void addEnv(Env env) {
+        this.env.add(env);
+    }
+
+    public void addEnvs(List<Env> envs) {
+        this.env.addAll(envs);
+    }
+
+    public Env[] getEnv() {
+        return env.toArray(new Env[0]);
+    }
+
+    public void setEnv(Env[] env) {
+        this.env = Arrays.asList(env);
     }
 }

--- a/openshift-example-tests/src/main/java/org/kogito/examples/openshift/operator/model/Env.java
+++ b/openshift-example-tests/src/main/java/org/kogito/examples/openshift/operator/model/Env.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kogito.examples.openshift.operator.model;
+
+/**
+ * KogitoApp environment variable.
+ */
+public class Env {
+
+    private String name;
+    private String value;
+
+    public Env() {}
+
+    public Env(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/openshift-example-tests/src/test/java/org/kogito/examples/openshift/DroolsQuarkusExampleKogitoOperatorIntegrationTest.java
+++ b/openshift-example-tests/src/test/java/org/kogito/examples/openshift/DroolsQuarkusExampleKogitoOperatorIntegrationTest.java
@@ -28,6 +28,7 @@ import org.kogito.examples.openshift.operator.KogitoApp;
 import org.kogito.examples.openshift.operator.KogitoAppDoneable;
 import org.kogito.examples.openshift.operator.KogitoAppList;
 import org.kogito.examples.openshift.operator.model.Build;
+import org.kogito.examples.openshift.operator.model.Env;
 import org.kogito.examples.openshift.operator.model.GitSource;
 import org.kogito.examples.openshift.operator.model.Spec;
 
@@ -46,6 +47,7 @@ public class DroolsQuarkusExampleKogitoOperatorIntegrationTest extends DroolsQua
 
         Build build = new Build();
         build.setGitSource(gitSource);
+        TestConfig.getMavenMirrorUrl().ifPresent(mavenMirrorUrl -> build.addEnv(new Env("MAVEN_MIRROR_URL", mavenMirrorUrl)));
 
         Spec spec = new Spec();
         spec.setBuild(build);


### PR DESCRIPTION
@ricardozanini Can you please take a look?
It is used to speed up S2I build and reduce usage of default Maven repo.