### PR TITLE
KOGITO-102: jBPM Rule Unit integration

### DIFF
--- a/jbpm-quarkus-example/src/main/java/org/kie/kogito/examples/PersonValidationService.java
+++ b/jbpm-quarkus-example/src/main/java/org/kie/kogito/examples/PersonValidationService.java
@@ -1,0 +1,14 @@
+package org.kie.kogito.examples;
+
+import org.kie.kogito.examples.demo.Person;
+import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.RuleUnitMemory;
+
+public class PersonValidationService implements RuleUnitMemory {
+    private DataStore<Person> persons = DataSource.createStore();
+
+    public DataStore<Person> getPersons() {
+        return persons;
+    }
+}

--- a/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/PersonValidationService.drl
+++ b/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/PersonValidationService.drl
@@ -1,12 +1,11 @@
-package org.acme.kogito
+package org.kie.kogito.examples
+unit PersonValidationService
 
 import org.kie.kogito.examples.demo.Person;
 
-
-rule "Is adult" ruleflow-group "person"
-
+rule "Is adult"
 when
-    $person: Person(age > 18)
+    $person: /persons[age > 18]
 then
     modify($person) { 
     	setAdult(true) 

--- a/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
+++ b/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
@@ -19,10 +19,10 @@
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
     <!--
-      'ruleFlowGroup="unit:PersonValidationService"' or ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService"
+      ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService"
       may be used ad-interim, until we support 'tns:ruleUnit="..."' — especially tooling-wise
     -->
-    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="unit:PersonValidationService" name="Evaluate person">
+    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService" name="Evaluate person">
       <bpmn2:extensionElements>
         <tns:metaData name="elementname">
           <tns:metaValue><![CDATA[Evaluate person]]></tns:metaValue>

--- a/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
+++ b/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
@@ -18,7 +18,11 @@
       </bpmn2:extensionElements>
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
-    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="person" name="Evaluate person">
+    <!--
+      'ruleFlowGroup="unit:PersonValidationService"' or ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService"
+      may be used ad-interim, until we support 'tns:ruleUnit="..."' — especially tooling-wise
+    -->
+    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="unit:PersonValidationService" name="Evaluate person">
       <bpmn2:extensionElements>
         <tns:metaData name="elementname">
           <tns:metaValue><![CDATA[Evaluate person]]></tns:metaValue>
@@ -27,8 +31,8 @@
       <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
       <bpmn2:ioSpecification id="InputOutputSpecification_2">
-        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_51" name="person"/>
-        <bpmn2:dataOutput id="DataOutput_1" itemSubjectRef="ItemDefinition_51" name="person"/>
+        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_51" name="persons"/>
+        <bpmn2:dataOutput id="DataOutput_1" itemSubjectRef="ItemDefinition_51" name="persons"/>
         <bpmn2:inputSet id="InputSet_2" name="Input Set 2">
           <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
         </bpmn2:inputSet>

--- a/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
+++ b/jbpm-quarkus-example/src/main/resources/org/kie/kogito/examples/persons.bpmn2
@@ -19,10 +19,10 @@
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
     <!--
-      ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService"
-      may be used ad-interim, until we support 'tns:ruleUnit="..."' — especially tooling-wise
+      ruleFlowGroup="org.kie.kogito.examples.PersonValidationService"
+      with implementation="http://www.jboss.org/drools/rule-unit" means ruleFlowGroup indicates a unit
     -->
-    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="unit:org.kie.kogito.examples.PersonValidationService" name="Evaluate person">
+    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="org.kie.kogito.examples.PersonValidationService" name="Evaluate person" implementation="http://www.jboss.org/drools/rule-unit">
       <bpmn2:extensionElements>
         <tns:metaData name="elementname">
           <tns:metaValue><![CDATA[Evaluate person]]></tns:metaValue>


### PR DESCRIPTION
Brainstorming integration API, TBD runtime support.

- `PersonRules` is a rule unit (silly rule for now, we will make it better)
  - `persons` is a `DataStore<Person>`
- PersonsProcess has a `Person person` variable
    - it calls into rule unit called `PersonRules` using a BusinessRuleTask 
    - input: maps `person` to data source `persons` (i.e. it **inserts** it implicitly inside)
    - output: maps `person` to data source `persons` (i.e. it takes one value -- this should be probably discussed: probably too much magic) -- notice we allow this because data sources may be seen as queries 

 