### PR TITLE
Switch onboarding deployment creations for onboarding test

### DIFF
--- a/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleKogitoOperatorIntegrationTest.java
+++ b/openshift-example-tests/src/test/java/org/kogito/examples/openshift/OnboardingQuarkusExampleKogitoOperatorIntegrationTest.java
@@ -42,14 +42,14 @@ public class OnboardingQuarkusExampleKogitoOperatorIntegrationTest extends Onboa
     public static void setUpOperator() {
         NonNamespaceOperation<KogitoApp, KogitoAppList, KogitoAppDoneable, Resource<KogitoApp, KogitoAppDoneable>> kogitoOperatorClient = OperatorDeployer.deployKogitoOperator(project);
 
-        kogitoOperatorClient.create(getOnboardingKogitoApp());
-        project.getMaster().waiters().areExactlyNPodsRunning(1, ONBOARDING_DEPLOYMENT_NAME).timeout(TimeUnit.MINUTES, 30L).waitFor();
+        kogitoOperatorClient.create(getHrKogitoApp());
+        project.getMaster().waiters().areExactlyNPodsRunning(1, HR_DEPLOYMENT_NAME).timeout(TimeUnit.MINUTES, 30L).waitFor();
 
         kogitoOperatorClient.create(getPayrollKogitoApp());
         project.getMaster().waiters().areExactlyNPodsRunning(1, PAYROLL_DEPLOYMENT_NAME).timeout(TimeUnit.MINUTES, 30L).waitFor();
 
-        kogitoOperatorClient.create(getHrKogitoApp());
-        project.getMaster().waiters().areExactlyNPodsRunning(1, HR_DEPLOYMENT_NAME).timeout(TimeUnit.MINUTES, 30L).waitFor();
+        kogitoOperatorClient.create(getOnboardingKogitoApp());
+        project.getMaster().waiters().areExactlyNPodsRunning(1, ONBOARDING_DEPLOYMENT_NAME).timeout(TimeUnit.MINUTES, 30L).waitFor();
 
         onboardingDeployment = new HttpDeployment(project, ONBOARDING_DEPLOYMENT_NAME);
         HttpDeployment payrollDeployment = new HttpDeployment(project, ONBOARDING_DEPLOYMENT_NAME);


### PR DESCRIPTION
Create onboarding as a last deployment.
Previous the test request was sent to onboarding app even before HR app was completely initialized and its service available from onboarding app - caused test instabilities.
By building onboarding app as latest we ensure that once onboarding app is built and started the other apps are already available.

@ricardozanini Can you please take a look?