### PR TITLE
KOGITO-366 DMN fix OCP asset resolution errors

### DIFF
--- a/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/PaymentDateDMNEndpoint.java
+++ b/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/PaymentDateDMNEndpoint.java
@@ -32,7 +32,7 @@ import org.kie.kogito.examples.payroll.Payroll;
 @Path("/paymentDate")
 public class PaymentDateDMNEndpoint {
 
-    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime();
+    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime(new java.io.InputStreamReader(PaymentDateDMNEndpoint.class.getResourceAsStream("/org/kie/kogito/examples/payroll/paymentDate.dmn")));
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/TaxRateDMNEndpoint.java
+++ b/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/TaxRateDMNEndpoint.java
@@ -33,7 +33,7 @@ import org.kie.kogito.examples.payroll.Payroll;
 @Path("/taxRate")
 public class TaxRateDMNEndpoint {
 
-    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime();
+    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime(new java.io.InputStreamReader(TaxRateDMNEndpoint.class.getResourceAsStream("/org/kie/kogito/examples/payroll/taxRate.dmn")));
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/VacationDaysDMNEndpoint.java
+++ b/onboarding-example/payroll/src/main/java/org/kie/kogito/examples/VacationDaysDMNEndpoint.java
@@ -33,7 +33,7 @@ import org.kie.kogito.examples.payroll.Payroll;
 @Path("/vacationDays")
 public class VacationDaysDMNEndpoint {
 
-    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime();
+    static final DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime(new java.io.InputStreamReader(VacationDaysDMNEndpoint.class.getResourceAsStream("/org/kie/kogito/examples/payroll/vacationDays.dmn")));
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Requires https://github.com/kiegroup/kogito-runtimes/pull/181

The scope of this PR is to fix OCP resolution errors.

@ricardozanini you may want to use this one, regardless of the "warn" message, to check you don't occur any longer in the "multiple model same name error".