### PR TITLE
KOGITO-1472 Random test failures on kogito-timer-quarkus example

### DIFF
--- a/kogito-timer-quarkus/src/test/java/org/acme/travels/BoundaryTimersProcessTest.java
+++ b/kogito-timer-quarkus/src/test/java/org/acme/travels/BoundaryTimersProcessTest.java
@@ -42,7 +42,7 @@ public class BoundaryTimersProcessTest {
         processInstance.start();
         assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, processInstance.status());
 
-        latch.await(1, TimeUnit.MINUTES);
+        latch.await(2, TimeUnit.MINUTES);
 
         Optional<? extends ProcessInstance<?>> exists = timersOnTaskProcess.instances().findById(processInstance.id());
         assertFalse(exists.isPresent());


### PR DESCRIPTION
I suspect this weird, intermittent trace in this test is caused by a timeout; maybe the timer goes off while the classfile is being read...

```
[INFO] -------------------------------------------------------

[INFO] Running org.acme.travels.BoundaryTimersProcessTest

2020-03-17 12:38:45,546 INFO  [org.kie.kog.cod.pro.ProcessCodegen] (build-7) Generating REST Resources.

2020-03-17 12:38:45,547 INFO  [org.kie.kog.cod.pro.ProcessCodegen] (build-7) Generating REST Resources.

2020-03-17 12:38:45,548 INFO  [org.kie.kog.cod.pro.ProcessCodegen] (build-7) Generating REST Resources.

2020-03-17 12:38:47,473 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.infinispan-client.server-list" was provided; it will be ignored

2020-03-17 12:38:48,264 INFO  [io.quarkus] (main) Quarkus 1.3.0.Final started in 4.000s. Listening on: http://0.0.0.0:8081

2020-03-17 12:38:48,264 INFO  [io.quarkus] (main) Profile test activated. 

2020-03-17 12:38:48,265 INFO  [io.quarkus] (main) Installed features: [cdi, kogito, resteasy, resteasy-jackson, smallrye-openapi, swagger-ui]

Before timer, waiting for task to be complete or expires in PT3S

After timer

2020-03-17 12:38:51,595 ERROR [org.jbp.wor.ins.imp.WorkflowProcessInstanceImpl] (pool-3-thread-1) Unexpected error (id feb5195b-bfa2-4b54-a90d-5935b54d9a9b) while executing node After Timer in process instance 8c99d6b6-9c70-40f0-a168-cf7e4f6aa0b7: java.lang.RuntimeException: Unable to read /home/jenkins/workspace/IE_kogito_kogito-runtimes_PR-372/jbpm/jbpm-flow/target/classes/org/jbpm/workflow/instance/node/EndNodeInstance.class

	at io.quarkus.bootstrap.classloading.DirectoryClassPathElement$1.getData(DirectoryClassPathElement.java:58)

	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:279)

	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:251)

	at org.jbpm.workflow.instance.impl.NodeInstanceFactoryRegistry.get(NodeInstanceFactoryRegistry.java:124)

	at org.jbpm.workflow.instance.impl.CodegenNodeInstanceFactoryRegistry.get(CodegenNodeInstanceFactoryRegistry.java:28)

	at org.jbpm.workflow.instance.impl.NodeInstanceFactoryRegistry.getProcessNodeInstanceFactory(NodeInstanceFactoryRegistry.java:100)

	at org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl.getNodeInstance(WorkflowProcessInstanceImpl.java:279)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.followConnection(NodeInstanceImpl.java:385)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.triggerCompleted(NodeInstanceImpl.java:351)

	at org.jbpm.workflow.instance.node.ActionNodeInstance.triggerCompleted(ActionNodeInstance.java:63)

	at org.jbpm.workflow.instance.node.ActionNodeInstance.internalTrigger(ActionNodeInstance.java:59)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.trigger(NodeInstanceImpl.java:200)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.triggerNodeInstance(NodeInstanceImpl.java:404)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.triggerNodeInstance(NodeInstanceImpl.java:389)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.triggerCompleted(NodeInstanceImpl.java:358)

	at org.jbpm.workflow.instance.impl.ExtendedNodeInstanceImpl.triggerCompleted(ExtendedNodeInstanceImpl.java:46)

	at org.jbpm.workflow.instance.node.EventNodeInstance.triggerCompleted(EventNodeInstance.java:152)

	at org.jbpm.workflow.instance.node.EventNodeInstance.signalEvent(EventNodeInstance.java:75)

	at org.jbpm.workflow.instance.node.BoundaryEventNodeInstance.signalEvent(BoundaryEventNodeInstance.java:46)

	at org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl.signalEvent(WorkflowProcessInstanceImpl.java:621)

	at org.jbpm.ruleflow.core.RuleFlowProcessFactory.lambda$timerAction$0(RuleFlowProcessFactory.java:275)

	at org.jbpm.workflow.instance.impl.NodeInstanceImpl.executeAction(NodeInstanceImpl.java:230)

	at org.jbpm.workflow.instance.node.StateBasedNodeInstance.triggerTimer(StateBasedNodeInstance.java:320)

	at org.jbpm.workflow.instance.node.StateBasedNodeInstance.signalEvent(StateBasedNodeInstance.java:299)

	at org.jbpm.workflow.instance.node.WorkItemNodeInstance.signalEvent(WorkItemNodeInstance.java:431)

	at org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl.signalEvent(WorkflowProcessInstanceImpl.java:607)

	at org.kie.services.jobs.impl.InMemoryJobService$SignalProcessInstanceOnExpiredTimer.lambda$run$0(InMemoryJobService.java:120)

	at org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(UnitOfWorkExecutor.java:33)

	at org.kie.services.jobs.impl.InMemoryJobService$SignalProcessInstanceOnExpiredTimer.run(InMemoryJobService.java:115)

	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)

	at java.util.concurrent.FutureTask.run(FutureTask.java:266)

	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)

	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)

	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)

	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)

	at java.lang.Thread.run(Thread.java:748)

Caused by: java.nio.channels.ClosedByInterruptException

	at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)

	at sun.nio.ch.FileChannelImpl.size(FileChannelImpl.java:315)

	at java.nio.file.Files.readAllBytes(Files.java:3154)

	at io.quarkus.bootstrap.classloading.DirectoryClassPathElement$1.getData(DirectoryClassPathElement.java:56)

	... 35 more


[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 65.806 s <<< FAILURE! - in org.acme.travels.BoundaryTimersProcessTest

[ERROR] testTimersProcess  Time elapsed: 60.332 s  <<< FAILURE!

org.opentest4j.AssertionFailedError: expected: <false> but was: <true>

	at org.acme.travels.BoundaryTimersProcessTest.testTimersProcess(BoundaryTimersProcessTest.java:48)

```