### PR TITLE
KOGITO-1523: All examples should use org.kie.kogito:kogito-quarkus

### DIFF
--- a/kogito-business-rules-quarkus/pom.xml
+++ b/kogito-business-rules-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-infinispan-persistence-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-kafka-quickstart-quarkus/pom.xml
@@ -35,8 +35,8 @@
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-scripts-quarkus/pom.xml
+++ b/kogito-scripts-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-service-calls-quarkus/pom.xml
+++ b/kogito-service-calls-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-service-rest-call-quarkus/pom.xml
+++ b/kogito-service-rest-call-quarkus/pom.xml
@@ -27,8 +27,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-timer-quarkus/pom.xml
+++ b/kogito-timer-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-usertasks-quarkus/pom.xml
+++ b/kogito-usertasks-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kogito-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-usertasks-with-security-oidc-quarkus/pom.xml
@@ -42,8 +42,8 @@
       <version>1.0.0.Alpha1</version>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
 
     <!--tests -->

--- a/kogito-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-usertasks-with-security-quarkus/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
we are still using io.quarkus:quarkus-kogito instead of org.kie.kogito:kogito-quarkus in some places