### PR TITLE
Remove unneeded version from travel agency pom

### DIFF
--- a/kogito-travel-agency/travels/pom.xml
+++ b/kogito-travel-agency/travels/pom.xml
@@ -140,7 +140,6 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <goals>
@@ -155,7 +154,6 @@
           </plugin>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/kogito-travel-agency/visas/pom.xml
+++ b/kogito-travel-agency/visas/pom.xml
@@ -108,7 +108,6 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <goals>
@@ -123,7 +122,6 @@
           </plugin>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Fix:

> The project org.kie.kogito:kogito-travel-agency:8.0.0-SNAPSHOT (/tmp/src/kogito-travel-agency/travels/pom.xml) has 2 errors
>      'build.plugins.plugin.version' for io.quarkus:quarkus-maven-plugin must be a valid version but is '${quarkus.version}'. @ line 143, column 22
>      'build.plugins.plugin.version' for org.apache.maven.plugins:maven-failsafe-plugin must be a valid version but is '${surefire-plugin.version}'. @ line 158, column 22