### PR TITLE
KOGITO-1361: Add memory limitation for native builds of Kogito examples

### DIFF
--- a/dmn-quarkus-example/src/main/resources/application.properties
+++ b/dmn-quarkus-example/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/kogito-travel-agency/travels/src/main/resources/application.properties
+++ b/kogito-travel-agency/travels/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 quarkus.http.cors=true
 quarkus.swagger-ui.always-include=true
 
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g
+
 kogito.service.url=http://localhost:8080
 kogito.dataindex.http.url=http://localhost:8180
 kogito.dataindex.ws.url=ws://localhost:8180

--- a/kogito-travel-agency/visas/src/main/resources/application.properties
+++ b/kogito-travel-agency/visas/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 quarkus.http.port=8090
 quarkus.http.cors=true
 
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g
+
 kogito.service.url=http://localhost:8090
 kogito.dataindex.http.url=http://localhost:8180
 kogito.dataindex.ws.url=ws://localhost:8180

--- a/onboarding-example/hr/src/main/resources/application.properties
+++ b/onboarding-example/hr/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 # Configuration file
 # key = value
 quarkus.http.port=8081
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/onboarding-example/onboarding-quarkus/src/main/resources/application.properties
+++ b/onboarding-example/onboarding-quarkus/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.infinispan-client.server-list=localhost:11222
 quarkus.infinispan-client.auth-username=
 quarkus.infinispan-client.auth-password=
 quarkus.infinispan-client.sasl-mechanism=
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=8g

--- a/onboarding-example/payroll/src/main/resources/application.properties
+++ b/onboarding-example/payroll/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 # Configuration file
 # key = value
 quarkus.http.port=8082
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-business-rules-quarkus/src/main/resources/application.properties
+++ b/process-business-rules-quarkus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-infinispan-persistence-quarkus/src/main/resources/application.properties
+++ b/process-infinispan-persistence-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 quarkus.swagger-ui.always-include=true
 
 quarkus.infinispan-client.server-list=localhost:11222
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-kafka-quickstart-quarkus/src/main/resources/application.properties
+++ b/process-kafka-quickstart-quarkus/src/main/resources/application.properties
@@ -16,3 +16,6 @@ mp.messaging.outgoing.processedtravellers.value.serializer=org.apache.kafka.comm
 
 # uncomment below line if you don't want to use cloud event payload format
 #kogito.messaging.as-cloudevents=false
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-quarkus-example/src/main/resources/application.properties
+++ b/process-quarkus-example/src/main/resources/application.properties
@@ -12,3 +12,6 @@ mp.messaging.outgoing.kogito-usertaskinstances-events.bootstrap.servers=
 mp.messaging.outgoing.kogito-usertaskinstances-events.connector=smallrye-kafka
 mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events
 mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-scripts-quarkus/src/main/resources/application.properties
+++ b/process-scripts-quarkus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-service-calls-quarkus/src/main/resources/application.properties
+++ b/process-service-calls-quarkus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-service-rest-call-quarkus/src/main/resources/application.properties
+++ b/process-service-rest-call-quarkus/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.swagger-ui.always-include=true
 
 org.acme.travels.rest.UsersRemoteService/mp-rest/url=https://petstore.swagger.io
 org.acme.travels.rest.UsersRemoteService/mp-rest/scope=javax.enterprise.context.ApplicationScoped
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-timer-quarkus/src/main/resources/application.properties
+++ b/process-timer-quarkus/src/main/resources/application.properties
@@ -7,3 +7,6 @@ kogito.service.url=http://localhost:8080
 
 
 %test.kogito.service.url=http://localhost:8081
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-usertasks-custom-lifecycle-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-custom-lifecycle-quarkus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-usertasks-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-quarkus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-usertasks-with-security-oidc-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-with-security-oidc-quarkus/src/main/resources/application.properties
@@ -6,3 +6,6 @@ quarkus.oidc.credentials.secret=secret
 
 quarkus.http.auth.permission.authenticated.paths=/*                                 
 quarkus.http.auth.permission.authenticated.policy=authenticated
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/process-usertasks-with-security-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-with-security-quarkus/src/main/resources/application.properties
@@ -9,3 +9,6 @@ quarkus.security.users.embedded.users.poul=poul
 quarkus.security.users.embedded.roles.poul=interns
 quarkus.security.users.embedded.auth-mechanism=BASIC
 quarkus.security.users.embedded.plain-text=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g

--- a/rules-quarkus-helloworld/src/main/resources/application.properties
+++ b/rules-quarkus-helloworld/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g

--- a/ruleunit-quarkus-example/src/main/resources/application.properties
+++ b/ruleunit-quarkus-example/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.swagger-ui.always-include=true
+
+# Maximum Java heap to be used during the native image generation
+quarkus.native.native-image-xmx=4g


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1361
Setting up the xmx parameter to 4g for all the kogito examples but the onboarding example which requires 8g (with less is failing).
I built all the kogito apps using the native maven profile with no issues.