### PR TITLE
[0.9.x] KOGITO-1696: Set quarkus default ports to avoid conflicts (#182)

### DIFF
--- a/onboarding-example/README.md
+++ b/onboarding-example/README.md
@@ -34,7 +34,7 @@ When using native image compilation, you will also need:
 
 ### Installation
 
-Please follow the instruction for each of the individual services
+Please follow the instruction for each of the individual services. It is recomended to install them in given order.
 
 * [hr](hr/README.md)
 * [payroll](payroll/README.md)

--- a/onboarding-example/hr/README.md
+++ b/onboarding-example/hr/README.md
@@ -35,11 +35,11 @@ Please replace {version} with the actual version of kogito you are trying to use
 ## OpenAPI (Swagger) documentation
 [Specification at swagger.io](https://swagger.io/docs/specification/about/)
 
-You can take a look at the [OpenAPI definition](http://localhost:8080/openapi?format=json) - automatically generated and included in this service - to determine all available operations exposed by this service. For easy readability you can visualize the OpenAPI definition file using a UI tool like for example available [Swagger UI](https://editor.swagger.io).
+You can take a look at the [OpenAPI definition](http://localhost:8081/openapi?format=json) - automatically generated and included in this service - to determine all available operations exposed by this service. For easy readability you can visualize the OpenAPI definition file using a UI tool like for example available [Swagger UI](https://editor.swagger.io).
 
 In addition, various clients to interact with this service can be easily generated using this OpenAPI definition.
 
-When running in Quarkus development mode, we also leverage the [Quarkus OpenAPI extension](https://quarkus.io/guides/openapi-swaggerui#use-swagger-ui-for-development) that exposes [Swagger UI](http://localhost:8080/swagger-ui/) that you can use to look at available REST endpoints and send test requests.
+When running in Quarkus development mode, we also leverage the [Quarkus OpenAPI extension](https://quarkus.io/guides/openapi-swaggerui#use-swagger-ui-for-development) that exposes [Swagger UI](http://localhost:8081/swagger-ui/) that you can use to look at available REST endpoints and send test requests.
 
 ## Example Usage
 

--- a/onboarding-example/hr/pom.xml
+++ b/onboarding-example/hr/pom.xml
@@ -49,10 +49,18 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemProperties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <configuration>
+          <debug>false</debug>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/onboarding-example/hr/src/test/resources/application.properties
+++ b/onboarding-example/hr/src/test/resources/application.properties
@@ -1,3 +1,3 @@
 # Configuration file
 # key = value
-quarkus.http.port=8081
+quarkus.http.test-port=8084

--- a/onboarding-example/onboarding/pom.xml
+++ b/onboarding-example/onboarding/pom.xml
@@ -52,11 +52,19 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemProperties>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>
           <debug>false</debug>
-          <jvmArgs>-Dquarkus.http.port=8080 -Dlocal=true -Dquarkus.http.host=localhost</jvmArgs>
+          <jvmArgs>-Dlocal=true</jvmArgs>
         </configuration>
         <executions>
           <execution>

--- a/onboarding-example/onboarding/src/main/resources/application.properties
+++ b/onboarding-example/onboarding/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Configuration file
 # key = value
+quarkus.http.port=8080
 quarkus.infinispan-client.server-list=localhost:11222
 quarkus.infinispan-client.auth-username=
 quarkus.infinispan-client.auth-password=

--- a/onboarding-example/onboarding/src/test/resources/application.properties
+++ b/onboarding-example/onboarding/src/test/resources/application.properties
@@ -1,3 +1,3 @@
 # Configuration file
 # key = value
-quarkus.http.port=8081
+quarkus.http.test-port=8083

--- a/onboarding-example/payroll/README.md
+++ b/onboarding-example/payroll/README.md
@@ -35,11 +35,11 @@ Please replace {version} with the actual version of kogito you are trying to use
 ## OpenAPI (Swagger) documentation
 [Specification at swagger.io](https://swagger.io/docs/specification/about/)
 
-You can take a look at the [OpenAPI definition](http://localhost:8080/openapi?format=json) - automatically generated and included in this service - to determine all available operations exposed by this service. For easy readability you can visualize the OpenAPI definition file using a UI tool like for example available [Swagger UI](https://editor.swagger.io).
+You can take a look at the [OpenAPI definition](http://localhost:8082/openapi?format=json) - automatically generated and included in this service - to determine all available operations exposed by this service. For easy readability you can visualize the OpenAPI definition file using a UI tool like for example available [Swagger UI](https://editor.swagger.io).
 
 In addition, various clients to interact with this service can be easily generated using this OpenAPI definition.
 
-When running in Quarkus development mode, we also leverage the [Quarkus OpenAPI extension](https://quarkus.io/guides/openapi-swaggerui#use-swagger-ui-for-development) that exposes [Swagger UI](http://localhost:8080/swagger-ui/) that you can use to look at available REST endpoints and send test requests.
+When running in Quarkus development mode, we also leverage the [Quarkus OpenAPI extension](https://quarkus.io/guides/openapi-swaggerui#use-swagger-ui-for-development) that exposes [Swagger UI](http://localhost:8082/swagger-ui/) that you can use to look at available REST endpoints and send test requests.
 
 ## Example Usage
 

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -67,7 +67,6 @@
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>
           <debug>false</debug>
-          <jvmArgs>-Dquarkus.http.port=8082 -Dquarkus.http.host=localhost</jvmArgs>
         </configuration>
         <executions>
           <execution>

--- a/onboarding-example/payroll/src/main/resources/application.properties
+++ b/onboarding-example/payroll/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 # Configuration file
 # key = value
-quarkus.http.port=8081
+quarkus.http.port=8082

--- a/onboarding-example/payroll/src/test/resources/application.properties
+++ b/onboarding-example/payroll/src/test/resources/application.properties
@@ -1,3 +1,3 @@
 # Configuration file
 # key = value
-quarkus.http.port=8081
+quarkus.http.test-port=8085


### PR DESCRIPTION
* KOGITO-1696: Set quarkus default ports to avoid conflicts

Set quarkus default ports for particular modules to avoid conflicts when running all modules
- hr : 8081
- payroll : 8082
- onboarding : 8080

For more details see https://issues.redhat.com/browse/KOGITO-1696

* Peer review - do not re-declare default host

* Use application.properties for port configuration

* Offset ports and correct READMEs

* Split main and test application.properties

Cherry-pick of #182 