### PR TITLE
KOGITO-1472 Random test failures on process-timer-quarkus example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <surefire.forkCount>1</surefire.forkCount>
     <alphanetworkCompilerEnabled>false</alphanetworkCompilerEnabled>
 
-    <version.io.quarkus>1.3.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.3.1.Final</version.io.quarkus>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/process-timer-quarkus/README.md
+++ b/process-timer-quarkus/README.md
@@ -81,12 +81,13 @@ This needs to be given when starting process instance as delay attribute of type
 
 ## Build and run
 
-By default the [Jobs Service integration](#use-kogito-job-service-as-external-timer-service) is enabled for this example. To disable it, just comment this dependency in the `pom.xml` file:
+By default the [Jobs Service integration](#use-kogito-job-service-as-external-timer-service) is not enabled for this 
+example. To enable it, just uncomment this dependency in the `pom.xml` file, [see](#configure-pomxml):
 
 ```xml
 <dependency>
   <groupId>org.kie.kogito</groupId>
-  <artifactId>jobs-management-springboot-addon</artifactId>
+  <artifactId>jobs-management-quarkus-addon</artifactId>
   <version>${kogito.version}</version>
 </dependency>
 ```

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -40,20 +40,26 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
+
+    <!-- uncomment to enable jobs service integration -->
+    <!--
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>jobs-management-quarkus-addon</artifactId>
     </dependency>
+    -->
 
     <!-- uncomment these two to enable persistence for kogito -->
-<!--     <dependency>
+    <!--
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-infinispan-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>infinispan-persistence-addon</artifactId>
-    </dependency> -->
+    </dependency>
+    -->
 
     <!--tests -->
     <dependency>

--- a/process-timer-quarkus/src/test/java/org/acme/travels/BoundaryTimersProcessTest.java
+++ b/process-timer-quarkus/src/test/java/org/acme/travels/BoundaryTimersProcessTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@Disabled("currently flaky, waiting on upstream fix Quarkus-side, see https://issues.redhat.com/browse/KOGITO-1543")
 public class BoundaryTimersProcessTest {
 
     @Inject

--- a/process-timer-quarkus/src/test/java/org/acme/travels/CycleTimersProcessTest.java
+++ b/process-timer-quarkus/src/test/java/org/acme/travels/CycleTimersProcessTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@Disabled("currently flaky, waiting on upstream fix Quarkus-side, see https://issues.redhat.com/browse/KOGITO-1543")
 public class CycleTimersProcessTest {
 
     @Inject

--- a/process-timer-quarkus/src/test/java/org/acme/travels/TimersProcessTest.java
+++ b/process-timer-quarkus/src/test/java/org/acme/travels/TimersProcessTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@Disabled("currently flaky, waiting on upstream fix Quarkus-side, see https://issues.redhat.com/browse/KOGITO-1543")
 public class TimersProcessTest {
 
     @Inject


### PR DESCRIPTION
- update quarkus 1.3.1, that should have the fix
- disable jobs-service integration by default (to allow tests to be enabled)
- re-enable tests
