### PR TITLE
KOGITO-1786: Cannot run Kogito Tests using Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,35 +258,6 @@
           <artifactId>kogito-maven-plugin</artifactId>
           <version>${project.version}</version>
         </plugin>
-        <!-- Added to avoid errors when importing sample projects into eclipse.-->
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.kie.kogito</groupId>
-                    <artifactId>kogito-maven-plugin</artifactId>
-                    <versionRange>[0.0.0,)</versionRange>
-                    <goals>
-                      <goal>injectreactive</goal>
-                      <goal>generateDMNModel</goal>
-                      <goal>generateModel</goal>
-                      <goal>process-model-classes</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
         <!-- Packaging -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1786
Description:
After adapting the kogito maven plugin to Eclipse and M2E (see [PR](https://github.com/kiegroup/kogito-runtimes/pull/448)), this plugin needs to be removed so Eclipse stops ignoring the plugin. 

This PR must be merged with this: https://github.com/kiegroup/kogito-runtimes/pull/448