### PR TITLE
[FAI-191] Implement test for Grafana dashboards in Kogito metrics

### DIFF
--- a/dmn-drools-quarkus-metrics/README.md
+++ b/dmn-drools-quarkus-metrics/README.md
@@ -70,9 +70,9 @@ You can use these default dashboards, or you can personalize them and use your c
 
 ### Compile and Run in Local Dev Mode
 
-A script `docker-compose/run-compose.sh` is provided to demonstrate how to inject the generated dashboards in the volume of the grafana container: 
-1. the generated dashboards are copied from `target/resources/dashboards/` to the directory `docker-compose/grafana/provisioning/dashboards`. 
-2. `docker-compose` is run. 
+It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
+1. Run `mvn clean package` to build the project and generate dashboards. 
+2. `docker-compose up` to start application. 
 
 The volumes of the grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are properly loaded at startup.
 

--- a/dmn-drools-quarkus-metrics/docker-compose.yml
+++ b/dmn-drools-quarkus-metrics/docker-compose.yml
@@ -2,14 +2,14 @@ version: '2'
 
 services:
   hello:
-    build: ../
+    build: ./
     ports:
       - 8080:8080
 
   prometheus:
     image: prom/prometheus:v2.8.0
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./docker-compose/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
@@ -23,6 +23,6 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./grafana/provisioning/:/etc/grafana/provisioning/
-      - ./grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./docker-compose/grafana/provisioning/:/etc/grafana/provisioning/
+      - ./docker-compose/grafana/grafana.ini:/etc/grafana/grafana.ini
 

--- a/dmn-drools-quarkus-metrics/docker-compose/run-compose.sh
+++ b/dmn-drools-quarkus-metrics/docker-compose/run-compose.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-cd ../
-mvn clean package
-
-cd docker-compose/ 
-cp ../target/generated-resources/kogito/dashboards/* grafana/provisioning/dashboards
-
-docker-compose build && docker-compose up

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -58,6 +58,16 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -79,6 +89,44 @@
             <goals>
               <goal>build</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.basedir}/docker-compose/grafana/provisioning/dashboards</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/generated-resources/kogito/dashboards</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              </systemProperties>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/dmn-drools-quarkus-metrics/src/test/java/org/kie/kogito/examples/GrafanaDockerComposeIT.java
+++ b/dmn-drools-quarkus-metrics/src/test/java/org/kie/kogito/examples/GrafanaDockerComposeIT.java
@@ -1,0 +1,71 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.examples;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.arrayContaining;
+
+import java.io.File;
+
+@Testcontainers
+public class GrafanaDockerComposeIT {
+
+    private static final String GRAFANA_URL = "http://localhost:3000";
+    private static final String PROMETHEUS_PRIVATE_URL = "http://prometheus:9090";
+
+    @Container
+    public static DockerComposeContainer environment =
+            new DockerComposeContainer(new File("./docker-compose.yml"))
+                    .withExposedService("grafana_1", 3000, Wait.forHttp("/")
+                            .forStatusCode(200));
+    
+    @Test
+    public void testPrometheusDataSource() {
+        given()
+                .baseUri(GRAFANA_URL)
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/datasources")
+                .then()
+                .statusCode(200)
+                .body("type", hasItem("prometheus"))
+                .body("url", hasItem(PROMETHEUS_PRIVATE_URL));
+    }
+
+    @Test
+    public void testGrafanaDashboards() {
+        given()
+                .baseUri(GRAFANA_URL)
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/search")
+                .then()
+                .statusCode(200)
+                .body("title", hasItem("hello - Operational Dashboard"))
+                .body("title", hasItem("LoanEligibility - Domain Dashboard"))
+                .body("title", hasItem("LoanEligibility - Operational Dashboard"));
+    }
+}


### PR DESCRIPTION
@r00ta @danielezonca 
There is the first version of tests for Grafana and Prometheus integration in metrics example. I think there are few points for discussion:
1. It might be more time consuming to use container tests than usual Quarkus tests, which may result in longer build. Do we want these tests to be part of main build or should we use some special profile for these tests.
2. I use Maven failsafe plugin for Grafana tests. It seems not usual in this repo, but it is necessary because Docker build needs executable jar to build the image. Any objections or suggestions?
