### PR TITLE
KOGITO-2704: Use random ports for testcontainers in Kogito Examples

### DIFF
--- a/dmn-pmml-springboot-example/src/main/java/org/kie/dmnpmml/kogito/springboot/example/KogitoSpringbootApplication.java
+++ b/dmn-pmml-springboot-example/src/main/java/org/kie/dmnpmml/kogito/springboot/example/KogitoSpringbootApplication.java
@@ -18,10 +18,10 @@ package org.kie.dmnpmml.kogito.springboot.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages={"org.kie.dmnpmml.kogito.**", "org.kie.kogito.app.**"})
+@SpringBootApplication(scanBasePackages = {"org.kie.dmnpmml.kogito.**", "org.kie.kogito.app.**"})
 public class KogitoSpringbootApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(KogitoSpringbootApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(KogitoSpringbootApplication.class, args);
+    }
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2704
Description:  Using random ports will allow to build the KOGITO examples using parallel.

- Allocate a random TCP Port for all the test resources, be testcontainers or process.
- Normalize the way we use these testresources either in Spring Boot and Quarkus (use it in the same way: via annotation only). The framework will inject automatically the properties for you.
- Upgrade surefire/failsafe plugins, so we can build the modules in parallel (at the moment, there is an issue that says no tests found when running in parallel. This is solved upgrading the surefire version).

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
