### PR TITLE
[DO NOT MERGE] FAI-215: Model definition endpoint - preliminary work

### DIFF
--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -46,6 +46,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-tracing-decision-quarkus-addon</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/dmn-listener-quarkus/src/test/java/org/kie/dmn/kogito/quarkus/example/TrafficViolationListenerTest.java
+++ b/dmn-listener-quarkus/src/test/java/org/kie/dmn/kogito/quarkus/example/TrafficViolationListenerTest.java
@@ -48,7 +48,7 @@ public class TrafficViolationListenerTest {
                 .map(DecisionEventListenerConfig::listeners)
                 .orElseThrow(() -> new IllegalStateException("Can't find injected listeners"));
 
-        assertEquals(4, injectedListeners.size());
+        assertEquals(5, injectedListeners.size());
 
         MockDMNRuntimeEventListener testListener = injectedListeners.stream()
                 .filter(MockDMNRuntimeEventListener.class::isInstance)


### PR DESCRIPTION
**=== DO NOT MERGE ===**

See https://issues.redhat.com/browse/FAI-215

This is preliminary work; hence the draft status.

It demonstrates exposing the model XML to a class capable of emitting CloudEvents.

You can run the `dmn-listener-quarkus` example and observe the DMN model XML emitted to the stdout.

The changes here simply hijack an existing example for now.. hence this PR is not to be merged.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
