### PR TITLE
KOGITO-2744 Add maven-deploy-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,13 @@
           <version>${version.swagger.plugin}</version>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${version.deploy.plugin}</version>
+          <configuration>
+            <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+          </configuration>
+        </plugin>
+        <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.compiler.plugin}</version>
           <configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2744

Add maven-deploy-plugin configuration to workaround a build error in PNC. We currently define `<version.deploy.plugin>2.8.2</version.deploy.plugin>` but our build picks up 2.7 as we're not configuring the plugin. Adding plugin configuration mirroring kogito-runtimes.