### PR TITLE
KOGITO-3036: Remove KafkaClient from Kogito Runtimes

### DIFF
--- a/process-kafka-quickstart-quarkus/src/test/java/org/acme/travel/MessagingIT.java
+++ b/process-kafka-quickstart-quarkus/src/test/java/org/acme/travel/MessagingIT.java
@@ -29,10 +29,10 @@ import java.util.stream.IntStream;
 
 import javax.inject.Inject;
 
+import org.acme.travel.utils.KafkaClient;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.After;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.kafka.KafkaClient;
 import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,10 +57,10 @@ public class MessagingIT {
     @Inject
     private ObjectMapper objectMapper;
 
-    public KafkaClient kafkaClient;
-
     @ConfigProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
     private String kafkaBootstrapServers;
+
+    private KafkaClient kafkaClient;
 
     @Test
     public void testProcess() throws InterruptedException {

--- a/process-kafka-quickstart-quarkus/src/test/java/org/acme/travel/utils/KafkaClient.java
+++ b/process-kafka-quickstart-quarkus/src/test/java/org/acme/travel/utils/KafkaClient.java
@@ -1,0 +1,106 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.travel.utils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kafka client for Kogito Example tests.
+ */
+public class KafkaClient {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(KafkaClient.class);
+
+    private KafkaProducer<String, String> producer;
+    private KafkaConsumer<String, String> consumer;
+    private CountDownLatch shutdownLatch = new CountDownLatch(1);
+    private AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    public KafkaClient(String hosts) {
+        Properties producerConfig = new Properties();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, hosts);
+        producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, this.getClass().getName() + "Producer");
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producer = new KafkaProducer<>(producerConfig);
+
+        Properties consumerConfig = new Properties();
+        consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, hosts);
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, this.getClass().getName() + "Consumer");
+        consumer = new KafkaConsumer<>(consumerConfig);
+    }
+
+    public void consume(String topic, Consumer<String> callback) {
+        consumer.subscribe(Collections.singletonList(topic));
+
+        CompletableFuture.runAsync(() -> {
+            while (!shutdown.get()) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+
+                StreamSupport.stream(records.spliterator(), true)
+                             .map(ConsumerRecord::value)
+                             .forEach(callback::accept);
+
+                consumer.commitSync();
+            }
+            shutdownLatch.countDown();
+        });
+    }
+
+    public void produce(String data, String topic) {
+        producer.send(new ProducerRecord<>(topic, data), (m, ex) -> {
+            Optional.ofNullable(ex).ifPresent(e -> LOGGER.error("Error publishing message {}", m, ex));
+        });
+    }
+
+    public void shutdown() {
+        CompletableFuture.runAsync(() -> producer.close());
+        try {
+            shutdown.set(true);
+            shutdownLatch.await(1, TimeUnit.MINUTES);
+            consumer.close();
+        } catch (InterruptedException e) {
+            LOGGER.error("Error shutting down kafka consumer/producer", e);
+        }
+    }
+}

--- a/process-kafka-quickstart-springboot/src/test/java/org/acme/travel/MessagingIT.java
+++ b/process-kafka-quickstart-springboot/src/test/java/org/acme/travel/MessagingIT.java
@@ -27,14 +27,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.acme.travel.utils.KafkaClient;
 import org.junit.After;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.kafka.KafkaClient;
 import org.kie.kogito.testcontainers.springboot.KafkaSpringBootTestResource;
 import org.kie.kogito.tests.KogitoKafkaQuickstartSpringbootApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -56,11 +57,15 @@ public class MessagingIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String kafkaBootstrapServers;
+
     private KafkaClient kafkaClient;
 
     @Test
     public void testProcess() throws InterruptedException {
+        kafkaClient = new KafkaClient(kafkaBootstrapServers);
+
         objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
 
         //number of generated events to test

--- a/process-kafka-quickstart-springboot/src/test/java/org/acme/travel/utils/KafkaClient.java
+++ b/process-kafka-quickstart-springboot/src/test/java/org/acme/travel/utils/KafkaClient.java
@@ -1,0 +1,106 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.travel.utils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kafka client for Kogito Example tests.
+ */
+public class KafkaClient {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(KafkaClient.class);
+
+    private KafkaProducer<String, String> producer;
+    private KafkaConsumer<String, String> consumer;
+    private CountDownLatch shutdownLatch = new CountDownLatch(1);
+    private AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    public KafkaClient(String hosts) {
+        Properties producerConfig = new Properties();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, hosts);
+        producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, this.getClass().getName() + "Producer");
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producer = new KafkaProducer<>(producerConfig);
+
+        Properties consumerConfig = new Properties();
+        consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, hosts);
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, this.getClass().getName() + "Consumer");
+        consumer = new KafkaConsumer<>(consumerConfig);
+    }
+
+    public void consume(String topic, Consumer<String> callback) {
+        consumer.subscribe(Collections.singletonList(topic));
+
+        CompletableFuture.runAsync(() -> {
+            while (!shutdown.get()) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+
+                StreamSupport.stream(records.spliterator(), true)
+                             .map(ConsumerRecord::value)
+                             .forEach(callback::accept);
+
+                consumer.commitSync();
+            }
+            shutdownLatch.countDown();
+        });
+    }
+
+    public void produce(String data, String topic) {
+        producer.send(new ProducerRecord<>(topic, data), (m, ex) -> {
+            Optional.ofNullable(ex).ifPresent(e -> LOGGER.error("Error publishing message {}", m, ex));
+        });
+    }
+
+    public void shutdown() {
+        CompletableFuture.runAsync(() -> producer.close());
+        try {
+            shutdown.set(true);
+            shutdownLatch.await(1, TimeUnit.MINUTES);
+            consumer.close();
+        } catch (InterruptedException e) {
+            LOGGER.error("Error shutting down kafka consumer/producer", e);
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3036
Description: Duplicate KafkaClient utilities in only these two modules as it will be removed from the test utilities. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
