### PR TITLE
KOGITO-3080 - fix tracing example

### DIFF
--- a/dmn-tracing-quarkus/operator/dmn-tracing-example.yaml
+++ b/dmn-tracing-quarkus/operator/dmn-tracing-example.yaml
@@ -15,5 +15,6 @@ kind: KogitoRuntime
 metadata:
   name: dmn-tracing-quarkus
 spec:
+  enableEvents: true
   kafka:
     useKogitoInfra: true


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-3080

The integration test with the trusty operator is failing because this example is not started up. I think the issue is that the yaml file is wrong (and in addition to that the `enableEvents` flag was not included).

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
