### PR TITLE
[KOGITO-3158] Adding serverless rest example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <version.cloudevents.api>1.3.0</version.cloudevents.api>
     <!-- pmml -->
     <version.org.jpmml>1.5.1</version.org.jpmml>
+    <version.wiremock>2.27.2</version.wiremock>
 
   </properties>
 
@@ -199,6 +200,7 @@
         <module>serverless-workflow-service-calls-quarkus</module>
         <module>serverless-workflow-service-calls-springboot</module>
         <module>serverless-workflow-events-quarkus</module>
+        <module>serverless-workflow-functions-quarkus</module>
       </modules>
     </profile>
     <profile>
@@ -271,7 +273,12 @@
         <artifactId>pmml-model</artifactId>
         <version>${version.org.jpmml}</version>
       </dependency>
-
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8</artifactId>
+        <scope>test</scope>
+        <version>${version.wiremock}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/serverless-workflow-functions-quarkus/README.md
+++ b/serverless-workflow-functions-quarkus/README.md
@@ -1,0 +1,120 @@
+# Kogito Serverless Workflow - Rest Example
+
+## Description
+
+This example contains a workflow that performs two consecutive REST invocations defined as functions.  
+The workflow is described using JSON format as defined in the 
+[CNCF Serverless Workflow specification](https://github.com/cncf/wg-serverless/tree/master/workflow/spec).
+
+The workflow expects a JSON input containing a collections of numbers.
+
+The workflow starts invoking a GET to obtain a random integer. 
+This integer is passed together with the list of numbers to  a second REST invocation, a POST, which multiply each element of the array by the generated number
+and returns the sum. 
+Finally, the resulting integer is printed using sysout script. 
+
+## Installing and Running
+
+### Prerequisites
+ 
+You will need:
+  - Java 11+ installed
+  - Environment variable JAVA_HOME set accordingly
+  - Maven 3.6.2+ installed
+
+When using native image compilation, you will also need: 
+  - [GraalVm](https://www.graalvm.org/downloads/) 20.2.0+ installed
+  - Environment variable GRAALVM_HOME set accordingly
+  - Note that GraalVM native image compilation typically requires other packages (glibc-devel, zlib-devel and gcc) to be installed too.  You also need 'native-image' installed in GraalVM (using 'gu install native-image'). Please refer to [GraalVM installation documentation](https://www.graalvm.org/docs/reference-manual/aot-compilation/#prerequisites) for more details.
+
+### Compile and Run in Local Dev Mode
+
+```text
+mvn clean package quarkus:dev    
+```
+
+### Compile and Run in JVM mode
+
+```text
+mvn clean package 
+java -jar target/sw-quarkus-greeting-{version}-runner.jar    
+```
+
+or on windows
+
+```text
+mvn clean package
+java -jar target\sw-quarkus-greeting-{version}-runner.jar
+```
+
+### Compile and Run using Local Native Image
+Note that this requires GRAALVM_HOME to point to a valid GraalVM installation
+
+```text
+mvn clean package -Pnative
+```
+  
+To run the generated native executable, generated in `target/`, execute
+
+```text
+./target/sw-quarkus-greeting-{version}-runner
+```
+
+### Submit a request
+
+The service based on the JSON workflow definition can be access by sending a request to http://localhost:8080/RESTExample'
+with following content 
+
+```json
+{
+  "workflowdata": {
+   "inputNumbers": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            7
+        ]
+  }
+}
+```
+
+Complete curl command can be found below:
+
+```text
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"inputNumbers": [1,2,3,4,5,6,7,8,7]]}}' http://localhost:8080/RESTExample
+```
+
+Log after curl executed:
+
+```text
+{
+    "workflowdata": {
+        "inputNumbers": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            7
+        ],
+    }
+}
+
+```
+
+In Quarkus you should see the log message printed:
+
+```text
+The sum is: 387
+```
+## Deploying with Kogito Operator
+
+In the [`operator`](operator) directory you'll find the custom resources needed to deploy this example on OpenShift with the [Kogito Operator](https://docs.jboss.org/kogito/release/latest/html_single/#chap_kogito-deploying-on-openshift).

--- a/serverless-workflow-functions-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
+++ b/serverless-workflow-functions-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
@@ -1,0 +1,20 @@
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoBuild
+metadata:
+  name: serverless-workflow-greeting-quarkus
+spec:
+  type: RemoteSource
+  #envs:
+  # envs can be used to set variables during build
+  #- name: MY_CUSTOM_ENV
+  #  value: "my value"
+  gitSource:
+    contextDir: serverless-workflow-greeting-quarkus
+    uri: 'https://github.com/kiegroup/kogito-examples'
+  # set your maven nexus repository to speed up the build time
+  #mavenMirrorURL:
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoRuntime
+metadata:
+  name: serverless-workflow-greeting-quarkus

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-examples</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>serverless-workflow-functions-quarkus</artifactId>
+
+  <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>
+  <description>Kogito Serverless Workflow Example - Quarkus</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-rest-workitem</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>native-image</goal>
+                </goals>
+              </execution>
+            </executions>
+
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/serverless-workflow-functions-quarkus/src/main/java/org/acme/numbers/Numbers.java
+++ b/serverless-workflow-functions-quarkus/src/main/java/org/acme/numbers/Numbers.java
@@ -1,0 +1,26 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.numbers;
+
+import java.util.Collection;
+
+public class Numbers {
+    private Collection<Number> numbers;
+
+    public Collection<Number> getNumbers() {
+        return numbers;
+    }
+}

--- a/serverless-workflow-functions-quarkus/src/main/java/org/acme/numbers/NumbersResource.java
+++ b/serverless-workflow-functions-quarkus/src/main/java/org/acme/numbers/NumbersResource.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.numbers;
+
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Path("/numbers")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+public class NumbersResource {
+    
+    
+    private ObjectMapper objectMapper;
+    private Random rand; 
+    
+    @PostConstruct 
+    void init () {
+        objectMapper = new ObjectMapper();
+        rand = new Random(); 
+    }
+    
+    @GET
+    @Path("random")
+    public Response getRandom(@QueryParam("bound") @DefaultValue("10") int bound) {
+        return fromNumber("randomNumber", rand.nextInt(bound));
+    }
+    
+    @POST
+    @Path ("{number}/multiplyByAndSum")
+    public Response multiplyByAndSum (@PathParam("number") int multiplier, Numbers numbers) {
+        return fromNumber("sum", numbers.getNumbers().stream().map(n -> n.intValue()*multiplier).collect(Collectors.summingInt(Integer::intValue)));
+    }
+    
+    private Response fromNumber(String name, int number) {
+        return Response.ok().entity(objectMapper.createObjectNode().put(name,number)).build();
+    }
+
+}

--- a/serverless-workflow-functions-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-functions-quarkus/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+kogito.sw.functions.randomNumber.host=localhost
+kogito.sw.functions.randomNumber.port=8080
+kogito.sw.functions.multiplyAllByRandomAndSum.host=localhost
+kogito.sw.functions.multiplyAllByRandomAndSum.port=8080

--- a/serverless-workflow-functions-quarkus/src/main/resources/restfunctions.sw.json
+++ b/serverless-workflow-functions-quarkus/src/main/resources/restfunctions.sw.json
@@ -1,0 +1,88 @@
+{
+    "id": "RestExample",
+    "name": "Rest fun with numbers",
+    "version": "1.0v",
+    "functions": [
+        {
+            "name": "randomNumber",
+            "resource": "/numbers/random",
+            "type": "rest",
+            "metadata": {
+                "method": "GET"
+            }
+        },
+        {
+            "name": "multiplyAllByRandomAndSum",
+            "resource": "/numbers/{multiplier}/multiplyByAndSum",
+            "type": "rest",
+            "metadata": {
+                "method": "POST"
+            }
+        },
+        {
+            "name": "debug",
+            "type": "sysout"
+        }
+    ],
+    "states": [
+        {
+            "start": {
+                "kind": "default"
+            },
+            "name": "Calculations",
+            "type": "operation",
+            "actionMode": "sequential",
+            "actions": [
+                {
+                    "functionRef": {
+                        "refName": "randomNumber"
+                    }
+                },
+                {
+                    "functionRef": {
+                        "refName": "multiplyAllByRandomAndSum",
+                        "parameters": {
+                            "numbers": "$.inputNumbers",
+                            "multiplier": "$.randomNumber"
+                        }
+                    }
+                }
+            ],
+            "transition": {
+                "nextState": "SetMessage"
+            }
+        },
+        {
+            "name": "SetMessage",
+            "type": "inject",
+            "data": {
+                "message": "The sum is: "
+            },
+            "transition": {
+                "nextState": "PrintResult"
+            }
+        },
+        {
+            "name": "PrintResult",
+            "type": "operation",
+            "actionMode": "sequential",
+            "actions": [
+                {
+                    "name": "printAction",
+                    "functionRef": {
+                        "refName": "debug",
+                        "parameters": {
+                            "message": "$.message $.sum"
+                        }
+                    }
+                }
+            ],
+            "stateDataFilter": {
+                "dataOutputPath": "$.sum"
+            },
+            "end": {
+                "kind": "default"
+            }
+        }
+    ]
+}

--- a/serverless-workflow-functions-quarkus/src/test/java/org/acme/numbers/NumbersMockService.java
+++ b/serverless-workflow-functions-quarkus/src/test/java/org/acme/numbers/NumbersMockService.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.numbers;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+public class NumbersMockService implements QuarkusTestResourceLifecycleManager{
+
+    private WireMockServer wireMockServer;
+    
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(8080);
+        wireMockServer.start(); 
+        stubFor(get(urlEqualTo("/numbers/random"))   
+               .willReturn(aResponse()
+                       .withHeader("Content-Type", "application/json")
+                       .withBody("{\"randomNumber\": 1}")));
+        
+        stubFor(post(urlEqualTo("/numbers/1/multiplyByAndSum"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"sum\": 34}")));
+        
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+}

--- a/serverless-workflow-functions-quarkus/src/test/java/org/acme/numbers/RestExampleTest.java
+++ b/serverless-workflow-functions-quarkus/src/test/java/org/acme/numbers/RestExampleTest.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acme.numbers;
+
+import java.util.Collections;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.isEmptyOrNullString;;
+
+@QuarkusTest
+@QuarkusTestResource(NumbersMockService.class)
+class RestExampleTest {
+
+    @BeforeAll
+    static void init() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void testRestExample() {
+        given()
+            .contentType(ContentType.JSON)
+            .when()
+            .body(
+                  Collections
+                      .singletonMap(
+                                    "workflowdata",
+                                    Collections.singletonMap("inputNumbers", new int[]{1, 2, 3, 4, 5, 6, 7})))
+            .post("/RestExample")
+            .then()
+            .statusCode(201)
+            .body("id", not(isEmptyOrNullString()))
+            .body("workflowdata", not(isEmptyOrNullString()));
+    }
+}


### PR DESCRIPTION
Example that test the changes performed by #[778](https://github.com/kiegroup/kogito-runtimes/pull/778).

It is focus on sharing data between rest invocations

The example expects as input an array of numbers

There are two rest invocations, first one retrieve a random number, second one pass that number and the input array, multiply each element of the array by the random number and returns the sum

Finally, sum is printed