### PR TITLE
KOGITO-3421 Removing CloudEvents M1 from dep

### DIFF
--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -15,7 +15,6 @@
   <description>Kogito with Knative Eventing - Quarkus</description>
 
   <properties>
-    <version.cloudevents>2.0.0-milestone1</version.cloudevents>
     <version.wiremock>2.27.1</version.wiremock>
   </properties>
 
@@ -27,11 +26,6 @@
         <version>${kogito.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.cloudevents</groupId>
-        <artifactId>cloudevents-api</artifactId>
-        <version>${version.cloudevents}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/process-knative-quickstart-quarkus/src/test/java/org/acme/travel/CloudEventListenerTest.java
+++ b/process-knative-quickstart-quarkus/src/test/java/org/acme/travel/CloudEventListenerTest.java
@@ -100,7 +100,29 @@ public class CloudEventListenerTest {
         // have we received the message? We force the sleep since the WireMock framework doesn't support waiting/timeout verification
         LOGGER.info("Waiting 2 seconds to receive the produced message");
         Thread.sleep(2000);
-        sink.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(containing("specversion")));
         sink.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(containing("jane.doe@example.com")));
+    }
+
+    @Test
+    void checkStartNewProcessInstanceWithSourceField() throws JsonProcessingException, InterruptedException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Traveller traveller = new Traveller();
+        traveller.setFirstName("Jane");
+        traveller.setLastName("Doe");
+        traveller.setEmail("jane.doe2@example.com");
+        traveller.setNationality("German");
+
+        given()
+                .header("ce-specversion", "1.0")
+                .header("ce-id", "000")
+                .header("ce-source", "travellers")
+                .header("ce-type", "whatevertype")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(200);
+
+        // have we received the message? We force the sleep since the WireMock framework doesn't support waiting/timeout verification
+        LOGGER.info("Waiting 2 seconds to receive the produced message");
+        Thread.sleep(2000);
+        sink.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(containing("jane.doe2@example.com")));
     }
 }


### PR DESCRIPTION
Small update to remove M1 references from CloudEvents.

See: https://issues.redhat.com/browse/KOGITO-3421

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
