### PR TITLE
KOGITO-2773: Update scesim example enabling compatibility with BC

### DIFF
--- a/dmn-quarkus-example/src/test/resources/TrafficViolationTest.scesim
+++ b/dmn-quarkus-example/src/test/resources/TrafficViolationTest.scesim
@@ -73,7 +73,7 @@
             <name>Violation</name>
             <className>Violation</className>
           </factIdentifier>
-          <className>string</className>
+          <className>Type</className>
           <factAlias>Violation</factAlias>
           <expressionAlias>Type</expressionAlias>
           <genericTypes/>

--- a/dmn-springboot-example/src/test/resources/TrafficViolationTest.scesim
+++ b/dmn-springboot-example/src/test/resources/TrafficViolationTest.scesim
@@ -73,7 +73,7 @@
             <name>Violation</name>
             <className>Violation</className>
           </factIdentifier>
-          <className>string</className>
+          <className>Type</className>
           <factAlias>Violation</factAlias>
           <expressionAlias>Type</expressionAlias>
           <genericTypes/>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2773

The real name of "Type" column is "Type" and not "string". The editor will show "string" but, under the cover, "Type" is used because is a "Anonymous" DMNType (a type with allowed values). This change will enable the examples to be both compatible with Kogito channels and Business Central


- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
