### PR TITLE
KOGITO-3309: kogito-bom doesn't manage kogito-test-utils

### DIFF
--- a/dmn-tracing-springboot/pom.xml
+++ b/dmn-tracing-springboot/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/process-infinispan-persistence-springboot/pom.xml
+++ b/process-infinispan-persistence-springboot/pom.xml
@@ -76,6 +76,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/process-kafka-quickstart-springboot/pom.xml
+++ b/process-kafka-quickstart-springboot/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -70,6 +70,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/process-springboot-example/pom.xml
+++ b/process-springboot-example/pom.xml
@@ -77,6 +77,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
parent PR https://github.com/kiegroup/kogito-runtimes/pull/827

jira -> https://issues.redhat.com/browse/KOGITO-3309

kogito-bom should be only user end BOM so changing a hierarchy and therefore kogito-test-utils as internal dependency needs version declaration.