### PR TITLE
KOGITO-3710: Increase Native Image Xmx settings for some Kogito Examples

### DIFF
--- a/kogito-travel-agency/extended/travels/src/main/resources/application.properties
+++ b/kogito-travel-agency/extended/travels/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.http.cors=true
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation
-quarkus.native.native-image-xmx=4g
+quarkus.native.native-image-xmx=6g
 
 kogito.service.url=http://localhost:8080
 kogito.dataindex.http.url=http://localhost:8180

--- a/process-quarkus-example/src/main/resources/application.properties
+++ b/process-quarkus-example/src/main/resources/application.properties
@@ -14,4 +14,4 @@ mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinsta
 mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Maximum Java heap to be used during the native image generation
-quarkus.native.native-image-xmx=4g
+quarkus.native.native-image-xmx=6g


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3710
Description: Some Kogito Examples are failing to build the native image because the native compilation is limited to 4g.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
