### PR TITLE
 KOGITO-3689 Setup for use with Operator testing

### DIFF
--- a/process-mongodb-persistence-quarkus/operator/process-mongodb-persistence-quarkus.yaml
+++ b/process-mongodb-persistence-quarkus/operator/process-mongodb-persistence-quarkus.yaml
@@ -1,0 +1,29 @@
+## MongoDB operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-mongodb
+spec:
+  resource:
+    apiVersion: mongodb.com/v1
+    kind: MongoDB
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoBuild
+metadata:
+  name: process-mongodb
+spec:
+  type: RemoteSource
+  gitSource:
+    contextDir: process-mongodb-persistence-quarkus
+    uri: 'https://github.com/kiegroup/kogito-examples'
+  # set your maven nexus repository to speed up the build time
+  #mavenMirrorURL:
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoRuntime
+metadata:
+  name: process-mongodb
+spec:
+  infra:
+    - kogito-mongodb

--- a/process-mongodb-persistence-springboot/README.md
+++ b/process-mongodb-persistence-springboot/README.md
@@ -75,6 +75,11 @@ You will need:
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.6.2+ installed
 
+### Enable MongoDB configuration
+
+By default, MongoDB configuration properties are commented, due to conflict if configuration is coming from outside the code.  
+You should uncomment the commented `spring.data.mongodb` variables from [properties](./src/main/resources/application.properties) file.
+
 ### Compile and Run in Local Dev Mode
 
 ```

--- a/process-mongodb-persistence-springboot/operator/process-mongodb-persistence-springboot.yaml
+++ b/process-mongodb-persistence-springboot/operator/process-mongodb-persistence-springboot.yaml
@@ -1,0 +1,29 @@
+## MongoDB operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-mongodb
+spec:
+  resource:
+    apiVersion: mongodb.com/v1
+    kind: MongoDB
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoBuild
+metadata:
+  name: process-mongodb
+spec:
+  type: RemoteSource
+  gitSource:
+    contextDir: process-mongodb-persistence-springboot
+    uri: 'https://github.com/kiegroup/kogito-examples'
+  # set your maven nexus repository to speed up the build time
+  #mavenMirrorURL:
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoRuntime
+metadata:
+  name: process-mongodb
+spec:
+  infra:
+    - kogito-mongodb

--- a/process-mongodb-persistence-springboot/src/main/resources/application.properties
+++ b/process-mongodb-persistence-springboot/src/main/resources/application.properties
@@ -4,7 +4,6 @@ spring.mvc.servlet.path=/docs
 
 resteasy.jaxrs.scan-packages=org.kie.kogito.**
 
-spring.data.mongodb.uri=mongodb://localhost:27017
-
 kogito.persistence.type=mongodb
-spring.data.mongodb.database=Kogito_spring
+#spring.data.mongodb.uri=mongodb://localhost:27017
+#spring.data.mongodb.database=Kogito_spring

--- a/process-mongodb-persistence-springboot/src/main/resources/application.properties
+++ b/process-mongodb-persistence-springboot/src/main/resources/application.properties
@@ -5,5 +5,10 @@ spring.mvc.servlet.path=/docs
 resteasy.jaxrs.scan-packages=org.kie.kogito.**
 
 kogito.persistence.type=mongodb
+
+# Commented as this would interfere with external configuration in cloud/operator
+# This is due to the Spring Boot Starter MongoDB behavior ...
+# Conflicting with host/port setup if provided and incompatible with credentials ...
+# https://github.com/spring-projects/spring-boot/blob/b7fdf8fe87da1c01ff6aca041170a02f11280a1a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java#L61-L64
 #spring.data.mongodb.uri=mongodb://localhost:27017
 #spring.data.mongodb.database=Kogito_spring


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3689

- Added operator yaml.
- Disable default mongodb config on Spring Boot because conflicting with external configuration of the example (for example with operator setting configuration).
This is due to the Spring Boot Starter MongoDB behavior ... uri conflicting with host/port setup if provided and incompatible with credentials ... See https://github.com/spring-projects/spring-boot/blob/b7fdf8fe87da1c01ff6aca041170a02f11280a1a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java#L61-L64

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
