### PR TITLE
KOGITO-3577 Re-enable process-optaplanner-quarkus after DROOLS-5795

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,8 +269,7 @@
         <module>process-kafka-quickstart-quarkus</module>
         <module>process-knative-quickstart-quarkus</module>
         <module>process-mongodb-persistence-quarkus</module>
-        <!-- Disabled due to https://issues.redhat.com/browse/KOGITO-3577 -->
-        <!-- <module>process-optaplanner-quarkus</module> --> 
+        <module>process-optaplanner-quarkus</module>
         <module>process-quarkus-example</module>
         <module>process-scripts-quarkus</module>
         <module>process-service-calls-quarkus</module>


### PR DESCRIPTION
DROOLS-5795 fixes `process-optaplanner-quarkus`, so I am re-enabling it.
Merge after DROOLS-5795 is available in a Drools tagged release, hopefully today or tomorrow.

Referenced PRs: 
https://github.com/kiegroup/drools/pull/3215

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
