### PR TITLE
[1.0.x] KOGITO-3577 Re-enable process-optaplanner-quarkus after DROOLS-5795

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,8 +269,7 @@
         <module>process-kafka-quickstart-quarkus</module>
         <module>process-knative-quickstart-quarkus</module>
         <module>process-mongodb-persistence-quarkus</module>
-        <!-- Disabled due to https://issues.redhat.com/browse/KOGITO-3577 -->
-        <!-- <module>process-optaplanner-quarkus</module> --> 
+        <module>process-optaplanner-quarkus</module>
         <module>process-quarkus-example</module>
         <module>process-scripts-quarkus</module>
         <module>process-service-calls-quarkus</module>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>github-service</artifactId>
-  <name>Kogito Examples :: Serverless Workflow Github Showcase :: GitHub Service</name>
+  <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>
 
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>notification-service</artifactId>
-  <name>Kogito Examples :: Serverless Workflow Github Showcase :: Notification Service</name>
+  <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>
 
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>pr-checker-workflow</artifactId>
-  <name>Kogito Examples :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>
+  <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Cherry-pick to 1.0.x

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
