### PR TITLE
KOGITO-3862 - Make Docker images used by TestContainers compatible with Docker registry mirror

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
     <!-- infinispan -->
     <infinispan.version>11.0.4.Final</infinispan.version>
     <infinispan.starter.version>2.3.3.Final</infinispan.starter.version>
-    <container.image.infinispan>quay.io/infinispan/server:${infinispan.version}</container.image.infinispan>
+    <container.image.infinispan>infinispan/server:${infinispan.version}</container.image.infinispan>
     <!-- keycloak -->
-    <keycloak.version>11.0.0</keycloak.version>
-    <container.image.keycloak>quay.io/keycloak/keycloak:${keycloak.version}</container.image.keycloak>
+    <keycloak.version>11.0.1</keycloak.version>
+    <container.image.keycloak>jboss/keycloak:${keycloak.version}</container.image.keycloak>
     <!-- testcontainers -->
-    <version.testcontainers>1.14.3</version.testcontainers>
+    <version.testcontainers>1.15.0</version.testcontainers>
     <!-- jsonpath-->
     <version.jayway.jsonpath>2.4.0</version.jayway.jsonpath>
     <version.swagger.plugin>2.1.0</version.swagger.plugin>


### PR DESCRIPTION
Assembly:
- https://github.com/kiegroup/kogito-runtimes/pull/892
- https://github.com/kiegroup/kogito-examples/pull/457