### PR TITLE
Fix CI error when close to midnight

### DIFF
--- a/serverless-workflow-functions-events-quarkus/src/test/java/org/acme/sw/onboarding/services/ScheduleServiceTest.java
+++ b/serverless-workflow-functions-events-quarkus/src/test/java/org/acme/sw/onboarding/services/ScheduleServiceTest.java
@@ -40,6 +40,7 @@ class ScheduleServiceTest {
     void verifyAppointments() {
         final List<Doctor> doctors = DoctorService.get().getDoctors();
         // Michael and Mark are assigned to the same doctor, let's see the outcome.
+        final LocalDateTime beforeAppointment = LocalDateTime.now();
         final Patient michael = new Patient();
         michael.setName("Michael");
         michael.setAssignedDoctor(doctors.get(0));
@@ -61,6 +62,6 @@ class ScheduleServiceTest {
 
         assertTrue(markAppointment.getDate().isAfter(michaelAppointment.getDate()));
         assertEquals(ScheduleService.FIRST_HOUR_MORNING, markAppointment.getDate().getHour());
-        assertEquals(LocalDateTime.now().getDayOfMonth(), michaelAppointment.getDate().getDayOfMonth());
+        assertTrue(michaelAppointment.getDate().isAfter(beforeAppointment));
     }
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Small patch to fix this error:

```
Error Message

expected: <23> but was: <24>

Stacktrace

org.opentest4j.AssertionFailedError: expected: <23> but was: <24>
	at org.acme.sw.onboarding.services.ScheduleServiceTest.verifyAppointments(ScheduleServiceTest.java:64)

Standard Output

2020-11-23 23:05:39,266 WARN  [io.qua.deployment] (main) Producing values from constructors and fields is no longer supported and will be removed in a future release: 
```

There was a flaw in the test when running close to midnight. :facepalm: 

Thanks @cristianonicolai for pointing this out.
