### PR TITLE
A small fix to always generate operationId in the patient onboarding example

### DIFF
--- a/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.swagger-ui.always-include=true
+mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
 mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http
 quarkus.log.category."org.acme".level=DEBUG
 kogito.sw.functions.StoreNewPatient.host=localhost


### PR DESCRIPTION
A small workaround until [KOGITO-3958](https://issues.redhat.com/browse/KOGITO-3958) is not ready.