### PR TITLE
KOGITO-4075 - Add microprofile default config for tracing addon

### DIFF
--- a/dmn-tracing-quarkus/README.md
+++ b/dmn-tracing-quarkus/README.md
@@ -18,6 +18,15 @@ When using native image compilation, you will also need:
   - Environment variable GRAALVM_HOME set accordingly
   - Note that GraalVM native image compilation typically requires other packages (glibc-devel, zlib-devel and gcc) to be installed too.  You also need 'native-image' installed in GraalVM (using 'gu install native-image'). Please refer to [GraalVM installation documentation](https://www.graalvm.org/docs/reference-manual/aot-compilation/#prerequisites) for more details.
 
+### Configuration of the tracing addon
+
+The default configuration pushes the decision tracing events to the kafka topic `kogito-tracing-decision` and the DMN models used by the kogito application to `kogito-tracing-model` under the group-id `kogito-runtimes`. 
+The configuration can be customized according to https://quarkus.io/guides/kafka and https://kafka.apache.org/documentation/#producerconfigs using the prefix `mp.messaging.outgoing.kogito-tracing-decision.<property_name>`. 
+For example, in order to change the topic name for the decision tracing events, add the following line to the `application.properties` file:
+ ```
+mp.messaging.outgoing.kogito-tracing-decision.topic=my-kogito-tracing-decision
+```
+
 ### Compile and Run in Local Dev Mode
 
 ```

--- a/dmn-tracing-quarkus/README.md
+++ b/dmn-tracing-quarkus/README.md
@@ -21,7 +21,7 @@ When using native image compilation, you will also need:
 ### Configuration of the tracing addon
 
 The default configuration pushes the decision tracing events to the kafka topic `kogito-tracing-decision` and the DMN models used by the kogito application to `kogito-tracing-model` under the group-id `kogito-runtimes`. 
-The configuration can be customized according to https://quarkus.io/guides/kafka and https://kafka.apache.org/documentation/#producerconfigs using the prefix `mp.messaging.outgoing.kogito-tracing-decision.<property_name>`. 
+The configuration can be customized according to [https://quarkus.io/guides/kafka](https://quarkus.io/guides/kafka) and [https://kafka.apache.org/documentation/#producerconfigs](https://kafka.apache.org/documentation/#producerconfigs) using the prefix `mp.messaging.outgoing.kogito-tracing-decision.<property_name>`. 
 For example, in order to change the topic name for the decision tracing events, add the following line to the `application.properties` file:
  ```
 mp.messaging.outgoing.kogito-tracing-decision.topic=my-kogito-tracing-decision

--- a/dmn-tracing-quarkus/src/main/resources/application.properties
+++ b/dmn-tracing-quarkus/src/main/resources/application.properties
@@ -2,15 +2,3 @@ quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g
-
-# Kafka Tracing
-mp.messaging.outgoing.kogito-tracing-decision.group.id=kogito-runtimes
-mp.messaging.outgoing.kogito-tracing-decision.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-tracing-decision.topic=kogito-tracing-decision
-mp.messaging.outgoing.kogito-tracing-decision.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-
-# Kafka Tracing Model
-mp.messaging.outgoing.kogito-tracing-model.group.id=kogito-runtimes
-mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
-mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/dmn-tracing-quarkus/src/test/resources/application.properties
+++ b/dmn-tracing-quarkus/src/test/resources/application.properties
@@ -4,15 +4,3 @@ kafka.bootstrap.servers=localhost:9092
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g
-
-# Kafka Tracing
-mp.messaging.outgoing.kogito-tracing-decision.group.id=kogito-runtimes
-mp.messaging.outgoing.kogito-tracing-decision.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-tracing-decision.topic=kogito-tracing-decision
-mp.messaging.outgoing.kogito-tracing-decision.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-
-# Kafka Tracing Model
-mp.messaging.outgoing.kogito-tracing-model.group.id=kogito-runtimes
-mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
-mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/dmn-tracing-springboot/README.md
+++ b/dmn-tracing-springboot/README.md
@@ -13,6 +13,18 @@ You will need:
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.6.2+ installed
 
+### Configuration of the tracing addon
+
+The default configuration pushes the tracing events to the kafka topic `kogito-tracing-decision` and the DMN models used by the kogito application to `kogito-tracing-model` under the group-id `kogito-runtimes`. 
+Edit the `application.properties` file to change the configuration. The property names are the following: 
+
+- `kogito.addon.tracing.decision.kafka.bootstrapAddress`: The address used in the initial connection to find a bootstrap server on the cluster of `n` brokers (no default value, this is mandatory).
+- `kogito.addon.tracing.decision.kafka.topic.name` : The topic name for the decision tracing events (default `kogito-tracing-decision`).  
+- `kogito.addon.tracing.decision.kafka.topic.partitions` : How many partitions to use for the decision tracing events topic (default `1`).
+- `kogito.addon.tracing.decision.kafka.topic.replicationFactor` : The replication factor of the data for the decision tracing events topic (default `1`).
+- `kogito.addon.tracing.decision.asyncEnabled`: Use an asynchronous callback with the results of the send (success or failure) instead of waiting for the `Future` to complete (default `true`).
+- `kogito.addon.tracing.model.kafka.topic.name` : The topic name for the DMN models used by the kogito application (default `kogito-tracing-model`).
+
 ### Compile and Run in Local Dev Mode
 
 ```


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/KOGITO-4075

kogito-runtime pr: https://github.com/kiegroup/kogito-runtimes/pull/954

This PR aims to simplify the configuration of the tracing addon from the user. The default configuration is now placed inside the module, so the user does not have to specify the kafka topics and so on.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
