### PR TITLE
[KOGITO-4073] Update kogito-travel-agency-example scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ workspace
 #Scripts
 data-index-service*.jar
 management-console*.jar
-kogito-travel-agency/scripts/persistence/
+kogito-travel-agency/extended/scripts/persistence/
 
 #Grafana generated dashboards
 **/docker-compose/grafana/provisioning/dashboards/*.json

--- a/kogito-travel-agency/extended/scripts/startDataIndex.sh
+++ b/kogito-travel-agency/extended/scripts/startDataIndex.sh
@@ -7,11 +7,11 @@ echo "Project version: ${PROJECT_VERSION}"
 
 DATA_INDEX_VERSION=${PROJECT_VERSION}
 
-PERSISTENCE_FOLDER=target/classes/persistence
+PERSISTENCE_FOLDER=target/classes/META-INF/resources/persistence/protobuf
 DATA_INDEX_RUNNER="https://repository.jboss.org/nexus/service/local/artifact/maven/content?r=public&g=org.kie.kogito&a=data-index-service-infinispan&v=${DATA_INDEX_VERSION}&c=runner"
 
-KOGITO_TRAVEL_AGENCY_PERSISTENCE=../travels/target/classes/persistence
-KOGITO_VISAS_PERSISTENCE=../visas/target/classes/persistence
+KOGITO_TRAVEL_AGENCY_PERSISTENCE=../travels/target/classes/META-INF/resources/persistence/protobuf
+KOGITO_VISAS_PERSISTENCE=../visas/target/classes/META-INF/resources/persistence/protobuf
 
 mkdir -p $PERSISTENCE_FOLDER
 

--- a/kogito-travel-agency/extended/travels/README.md
+++ b/kogito-travel-agency/extended/travels/README.md
@@ -183,7 +183,7 @@ We provide a `startDataIndex.sh` and `startDataIndex.ps1` script in the `scripts
 
 If you wish to install, configure and start the **Data Index Service** manually, the _runnner_ can be downloaded from [Kogito Data Index Service](https://search.maven.org/artifact/org.kie.kogito/data-index)
 
-This service works with .proto (protobuf) files that define the data model. fter downloading the runner, create a new folder to store the .proto files that will be used by the service,  e.g. `persistence`. Copy the protobuf files from the **Kogito Travel Agency** and **Kogito Visas** application to the `persistence` folder. These files can be found in the `target/classes/persistence` folders of these projects.
+This service works with .proto (protobuf) files that define the data model. fter downloading the runner, create a new folder to store the .proto files that will be used by the service,  e.g. `persistence`. Copy the protobuf files from the **Kogito Travel Agency** and **Kogito Visas** application to the `persistence` folder. These files can be found in the `target/classes/META-INF/resources/persistence/protobuf` folders of these projects.
 
 To start the **Kogito Data Index Service**, execute the Java runner JAR of the service, providing it the location of the protobuf files:
 

--- a/kogito-travel-agency/extended/visas/README.md
+++ b/kogito-travel-agency/extended/visas/README.md
@@ -123,7 +123,7 @@ If you wish to install, configure and start the **Data Index Service** manually,
 
 After downloading the runner, create a new folder to store the .proto files that will be used by the service. 
 
-This service works with .proto files that define the data model. Once **Kogito Travel Service** is started, /target/classes/persistence/travels.proto is generated and it has to be copied to the new proto files folder.
+This service works with .proto files that define the data model. Once **Kogito Travel Service** is started, /target/classes/META-INF/resources/persistence/protobuf/travels.proto is generated and it has to be copied to the new proto files folder.
 
 To start the **Kogito Data Index Service** just past the full path of the proto files folder and execute 
 

--- a/process-infinispan-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-infinispan-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
@@ -98,6 +98,7 @@ public class DealsRestIT {
 
     @Test
     public void testProtobufListIsAvailable() {
+        @SuppressWarnings("unchecked")
         List<String> files = given().contentType(ContentType.JSON).accept(ContentType.JSON).when()
                 .get("/persistence/protobuf/list.json").as(List.class);
 

--- a/process-infinispan-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-infinispan-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/process-infinispan-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-infinispan-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
@@ -24,9 +24,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(initializers = InfinispanSpringBootTestResource.class)
@@ -101,5 +104,14 @@ public class DealsRestIT {
         given().accept(ContentType.JSON)
                 .when().get("/deals")
                 .then().statusCode(200).body("$.size()", is(0));
+    }
+
+    @Test
+    public void testProtobufListIsAvailable() {
+        @SuppressWarnings("unchecked")
+        List<String> files = given().contentType(ContentType.JSON).accept(ContentType.JSON).when()
+                .get("/persistence/protobuf/list.json").as(List.class);
+
+        assertEquals(2, files.size());
     }
 }

--- a/process-infinispan-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-infinispan-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4073

Details: update scripts of kogito-travel-agency-example because persistence proto files are now saved in `classes/META-INF/resources/persistence/protobuf` instead of `classes/persistence`

PR list:
- https://github.com/kiegroup/kogito-runtimes/pull/953
- https://github.com/kiegroup/kogito-examples/pull/494