### PR TITLE
[1.1.x] KOGITO-4093 quarkus bump 1.11.0.Beta2  (#499)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- Port 0 means dynamic port -->
     <tests.quarkus.http.port>0</tests.quarkus.http.port> 
 
-    <version.io.quarkus>1.10.3.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Beta2</version.io.quarkus>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/process-knative-quickstart-quarkus/src/test/resources/application.properties
+++ b/process-knative-quickstart-quarkus/src/test/resources/application.properties
@@ -1,8 +1,5 @@
 quarkus.http.test-port=8282
 quarkus.log.level=INFO
 
-# mocked during tests
-mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http
-
 mp.messaging.outgoing.processedtravellers.connector=smallrye-http
 mp.messaging.outgoing.processedtravellers.url=http://0.0.0.0:8181

--- a/process-quarkus-example/README.md
+++ b/process-quarkus-example/README.md
@@ -80,8 +80,8 @@ Kafka cluster installed and available over the network. Refer to [Kafka Apache s
 
 Kogito will use the following Kafka topics to listen for cloud events:
 
-* `kogito-processinstances-events` - used to emit events by kogito that can be consumed by data index service and other services
-* `kogito-usertaskinstances-events` -used to emit events by kogito that can be consumed by data index service
+* `kogito-processinstances-events` - used to emit events by Kogito that can be consumed by data index service and other services
+* `kogito-usertaskinstances-events` - used to emit events by Kogito that can be consumed by data index service and other services
 
 Once Kafka is up and running you can build this project with `-Pevents` to enable additional processing during the build. This extra profile in maven configuration adds additional dependencies needed to work with Cloud Events.
 

--- a/process-quarkus-example/src/main/resources/application.properties
+++ b/process-quarkus-example/src/main/resources/application.properties
@@ -13,5 +13,9 @@ mp.messaging.outgoing.kogito-usertaskinstances-events.connector=smallrye-kafka
 mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events
 mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
+mp.messaging.outgoing.kogito-variables-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-variables-events.topic=kogito-variables-events
+mp.messaging.outgoing.kogito-variables-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=6g

--- a/process-quarkus-example/src/test/resources/application.properties
+++ b/process-quarkus-example/src/test/resources/application.properties
@@ -6,3 +6,15 @@ quarkus.infinispan-client.server-list=localhost:11222
 quarkus.infinispan-client.use-auth=true
 quarkus.infinispan-client.auth-username=admin
 quarkus.infinispan-client.auth-password=admin
+
+mp.messaging.outgoing.kogito-processinstances-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-processinstances-events.topic=kogito-processinstances-events
+mp.messaging.outgoing.kogito-processinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.outgoing.kogito-usertaskinstances-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events
+mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.outgoing.kogito-variables-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-variables-events.topic=kogito-variables-events
+mp.messaging.outgoing.kogito-variables-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/serverless-workflow-github-showcase/pr-checker-workflow/src/test/resources/application.properties
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/src/test/resources/application.properties
@@ -2,7 +2,8 @@ quarkus.log.category."org.kogito".level=INFO
 quarkus.log.category."org.kie.kogito.app".level=INFO
 
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/url=
-mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.url=http://localhost:9090/
 
 # our sink server will sink these messages. See: org.kogito.examples.sw.github.workflow.MessageSinkServer
 mp.messaging.outgoing.pr_verified.connector=smallrye-http


### PR DESCRIPTION
* KOGITO-4093 quarkus bump 1.11.0.Beta2 + smallrye reactive messaging

* attempt to fix process-knative-quickstart-quarkus

* attempt to fix pr-checker-workflow

* Add MP connections to Kafka in test properties

Co-authored-by: Cristiano Nicolai <570894+cristianonicolai@users.noreply.github.com>
(cherry picked from commit acae3a42310e33c2641ff87a963b668ece71cf37)
