### PR TITLE
KOGITO-4125 - Mongodb persistence generates proto files during codegen

### DIFF
--- a/process-mongodb-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-mongodb-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
@@ -15,6 +15,7 @@
  */
 package org.acme.deals;
 
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -75,5 +76,14 @@ public class DealsRestIT {
         given().accept(ContentType.JSON)
                 .when().get("/deals")
                 .then().log().ifValidationFails().statusCode(200).body("$.size()", is(0));
+    }
+
+    @Test
+    public void testProtobufListIsAvailable() {
+        @SuppressWarnings("unchecked")
+        List<String> files = given().contentType(ContentType.JSON).accept(ContentType.JSON).when()
+                .get("/persistence/protobuf/list.json").as(List.class);
+
+        assertEquals(2, files.size());
     }
 }

--- a/process-mongodb-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/process-mongodb-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-4125

I was surfing around the codebase and I found out that the data index needs the protobuf files, but they are generated only if a persistence module is added as dependency and if kogito.persistence.type==infinispan. By consequence, if the user selects kogito.persistence.type=mongodb no proto files are generated/exposed and the data-index is not going to work.

This PR aims to add a test to check that the proto files are properly exposed for the operator.

PR on kogito-runtimes: https://github.com/kiegroup/kogito-runtimes/pull/967

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
