### PR TITLE
[KOGITO-4174] Fix license header in kogito-examples

### DIFF
--- a/serverless-workflow-temperature-conversion/conversion-workflow/src/test/java/org/kie/kogito/serverless/OperationsMockService.java
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/src/test/java/org/kie/kogito/serverless/OperationsMockService.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.serverless;
 
 import java.util.Collections;

--- a/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/MultiplicationOperation.java
+++ b/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/MultiplicationOperation.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import java.util.Objects;

--- a/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResource.java
+++ b/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResource.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import javax.validation.constraints.NotNull;

--- a/serverless-workflow-temperature-conversion/multiplication-service/src/test/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResourceTest.java
+++ b/serverless-workflow-temperature-conversion/multiplication-service/src/test/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResourceTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/serverless-workflow-temperature-conversion/subtraction-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResource.java
+++ b/serverless-workflow-temperature-conversion/subtraction-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResource.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import javax.validation.constraints.NotNull;

--- a/serverless-workflow-temperature-conversion/subtraction-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/SubtractionOperation.java
+++ b/serverless-workflow-temperature-conversion/subtraction-service/src/main/java/org/kie/kogito/examples/sw/temp/subtraction/SubtractionOperation.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import java.util.Objects;

--- a/serverless-workflow-temperature-conversion/subtraction-service/src/test/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResourceTest.java
+++ b/serverless-workflow-temperature-conversion/subtraction-service/src/test/java/org/kie/kogito/examples/sw/temp/subtraction/OperationResourceTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.kie.kogito.examples.sw.temp.subtraction;
 
 import io.quarkus.test.junit.QuarkusTest;


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4174

Master is failing because of `com.mycila:license-maven-plugin:3.0` license check