### PR TITLE
[1.3.x] KOGITO-4505 Use legacy-jar packaging in all Quarkus examples

### DIFF
--- a/decisiontable-quarkus-example/src/main/resources/application.properties
+++ b/decisiontable-quarkus-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/dmn-event-driven-quarkus/src/main/resources/application.properties
+++ b/dmn-event-driven-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/dmn-listener-quarkus/src/main/resources/application.properties
+++ b/dmn-listener-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/dmn-quarkus-example/src/main/resources/application.properties
+++ b/dmn-quarkus-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/dmn-springboot-example/src/main/resources/application.properties
+++ b/dmn-springboot-example/src/main/resources/application.properties
@@ -1,1 +1,4 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 server.address=0.0.0.0

--- a/dmn-tracing-quarkus/src/main/resources/application.properties
+++ b/dmn-tracing-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/flexible-process-quarkus/src/main/resources/application.properties
+++ b/flexible-process-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/kogito-quickstarts/01-kogito-basic-example/src/main/resources/application.properties
+++ b/kogito-quickstarts/01-kogito-basic-example/src/main/resources/application.properties
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+# Packaging
+quarkus.package.type=legacy-jar
+
+
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.cors=true
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/kogito-quickstarts/02-kogito-auth-example/src/main/resources/application.properties
+++ b/kogito-quickstarts/02-kogito-auth-example/src/main/resources/application.properties
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+# Packaging
+quarkus.package.type=legacy-jar
+
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.cors=true
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/kogito-travel-agency/basic/src/main/resources/application.properties
+++ b/kogito-travel-agency/basic/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 # Configuration file
 # key = value
+
+# Packaging
+quarkus.package.type=legacy-jar

--- a/kogito-travel-agency/extended/travels/src/main/resources/application.properties
+++ b/kogito-travel-agency/extended/travels/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.http.cors=true
 quarkus.swagger-ui.always-include=true
 

--- a/kogito-travel-agency/extended/visas/src/main/resources/application.properties
+++ b/kogito-travel-agency/extended/visas/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.http.port=8090
 quarkus.http.cors=true
 

--- a/onboarding-example/hr/src/main/resources/application.properties
+++ b/onboarding-example/hr/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 # Configuration file
 # key = value
+
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.http.port=8081
 
 # Maximum Java heap to be used during the native image generation

--- a/onboarding-example/onboarding-quarkus/src/main/resources/application.properties
+++ b/onboarding-example/onboarding-quarkus/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 # Configuration file
 # key = value
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.http.port=8080
 quarkus.infinispan-client.server-list=localhost:11222
 quarkus.infinispan-client.auth-username=

--- a/onboarding-example/payroll/src/main/resources/application.properties
+++ b/onboarding-example/payroll/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 # Configuration file
 # key = value
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.http.port=8082
 
 # Maximum Java heap to be used during the native image generation

--- a/pmml-quarkus-example/src/main/resources/application.properties
+++ b/pmml-quarkus-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.log.level=INFO

--- a/process-business-rules-quarkus/src/main/resources/application.properties
+++ b/process-business-rules-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/process-business-rules-springboot/src/main/resources/application.properties
+++ b/process-business-rules-springboot/src/main/resources/application.properties
@@ -1,1 +1,4 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 server.address=0.0.0.0

--- a/process-infinispan-persistence-quarkus/src/main/resources/application.properties
+++ b/process-infinispan-persistence-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.infinispan-client.server-list=localhost:11222

--- a/process-kafka-persistence-quarkus/src/main/resources/application.properties
+++ b/process-kafka-persistence-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 kogito.persistence.type=kafka

--- a/process-kafka-quickstart-quarkus/src/main/resources/application.properties
+++ b/process-kafka-quickstart-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 kafka.bootstrap.servers=localhost:9092

--- a/process-knative-quickstart-quarkus/src/main/resources/application.properties
+++ b/process-knative-quickstart-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http

--- a/process-mongodb-persistence-quarkus/src/main/resources/application.properties
+++ b/process-mongodb-persistence-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 kogito.persistence.type=mongodb
 

--- a/process-optaplanner-quarkus/src/main/resources/application.properties
+++ b/process-optaplanner-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 # The solver runs for 5 seconds. To run for 5 minutes use "5m" and for 2 hours use "2h".
 quarkus.optaplanner.solver.termination.spent-limit=5s
 resteasy.jaxrs.scan-packages=org.kie.kogito.**

--- a/process-quarkus-example/src/main/resources/application.properties
+++ b/process-quarkus-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.infinispan-client.server-list=localhost:11222

--- a/process-scripts-quarkus/src/main/resources/application.properties
+++ b/process-scripts-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/process-service-calls-quarkus/src/main/resources/application.properties
+++ b/process-service-calls-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/process-service-rest-call-quarkus/src/main/resources/application.properties
+++ b/process-service-rest-call-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 org.acme.travels.rest.UsersRemoteService/mp-rest/url=https://petstore.swagger.io

--- a/process-springboot-example/src/main/resources/application.properties
+++ b/process-springboot-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 infinispan.remote.server-list=localhost:11222
 
 spring.kafka.bootstrap-servers=localhost:9092

--- a/process-timer-quarkus/src/main/resources/application.properties
+++ b/process-timer-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.infinispan-client.server-list=localhost:11222

--- a/process-usertasks-custom-lifecycle-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-custom-lifecycle-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/process-usertasks-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/process-usertasks-with-security-oidc-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-with-security-oidc-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.oidc.auth-server-url=http://localhost:8281/auth/realms/kogito

--- a/process-usertasks-with-security-quarkus/src/main/resources/application.properties
+++ b/process-usertasks-with-security-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 quarkus.security.users.embedded.enabled=true

--- a/rules-quarkus-helloworld/src/main/resources/application.properties
+++ b/rules-quarkus-helloworld/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+# Packaging
+quarkus.package.type=legacy-jar
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g

--- a/ruleunit-quarkus-example/src/main/resources/application.properties
+++ b/ruleunit-quarkus-example/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation

--- a/serverless-workflow-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-events-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 kafka.bootstrap.servers=localhost:9092
 
 mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-kafka

--- a/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
 mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http

--- a/serverless-workflow-functions-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-functions-quarkus/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 kogito.sw.functions.randomNumber.host=localhost
 kogito.sw.functions.randomNumber.port=8080
 kogito.sw.functions.multiplyAllByRandomAndSum.host=localhost

--- a/serverless-workflow-github-showcase/github-service/src/main/resources/application.properties
+++ b/serverless-workflow-github-showcase/github-service/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 # for future reference, unfortunately the GitHub Client API library used in this
 # project is not compatible with native builds out of the box

--- a/serverless-workflow-greeting-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-greeting-quarkus/src/main/resources/application.properties
@@ -1,4 +1,2 @@
 # Packaging
 quarkus.package.type=legacy-jar
-
-quarkus.swagger-ui.always-include=true

--- a/serverless-workflow-service-calls-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-service-calls-quarkus/src/main/resources/application.properties
@@ -1,2 +1,5 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 org.kogito.serverless.examples.CountriesService/mp-rest/url=https://restcountries.eu/rest
 org.kogito.serverless.examples.CountriesService/mp-rest/scope=javax.inject.Singleton

--- a/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 # Service Discovery for Function Rest Calls
 kogito.sw.functions.subtraction.host=localhost
 kogito.sw.functions.subtraction.port=8181

--- a/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
+++ b/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
@@ -1,2 +1,5 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD

--- a/serverless-workflow-temperature-conversion/subtraction-service/src/main/resources/application.properties
+++ b/serverless-workflow-temperature-conversion/subtraction-service/src/main/resources/application.properties
@@ -1,2 +1,5 @@
+# Packaging
+quarkus.package.type=legacy-jar
+
 quarkus.swagger-ui.always-include=true
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4505
images/operators are still using the legacy file name