### PR TITLE
KOGITO-4770 Corrected native PR check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,8 +182,9 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true, b
     }
     if(canNative && isNative()) {
         mvnCmd.withProfiles(['native'])
-        // Added due to https://github.com/quarkusio/quarkus/issues/13341
-        mvnCmd.withProperty('quarkus.profile', 'native')
+            .withProperty('quarkus.native.container-build', true)
+            .withProperty('quarkus.native.container-runtime', 'docker')
+            .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
     }
     return mvnCmd
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4770

So we don't need to have the latest GraalVM on node for native building. It uses the quarkus provided docker image.

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1173
- https://github.com/kiegroup/optaplanner/pull/1232
- https://github.com/kiegroup/kogito-apps/pull/727
- https://github.com/kiegroup/kogito-examples/pull/626

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>
</details>