### PR TITLE
[KOGITO-4823] Fix README for fast-jar

### DIFF
--- a/decisiontable-quarkus-example/README.md
+++ b/decisiontable-quarkus-example/README.md
@@ -30,14 +30,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/decisiontable-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```
 mvn clean package
-java -jar target\decisiontable-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/dmn-event-driven-quarkus/README.md
+++ b/dmn-event-driven-quarkus/README.md
@@ -81,14 +81,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/dmn-tracing-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-tracing-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/dmn-event-driven-springboot/README.md
+++ b/dmn-event-driven-springboot/README.md
@@ -70,14 +70,14 @@ mvn clean compile spring-boot:run
 
 ```
 mvn clean package
-java -jar target/dmn-tracing-springboot.jar
+java -jar target/dmn-event-driven-springboot.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-tracing-springboot.jar
+java -jar target\dmn-event-driven-springboot.jar
 ```
 
 ## Example Usage

--- a/dmn-listener-quarkus/README.md
+++ b/dmn-listener-quarkus/README.md
@@ -32,14 +32,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/dmn-listener-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-listener-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/dmn-pmml-quarkus-example/README.md
+++ b/dmn-pmml-quarkus-example/README.md
@@ -25,14 +25,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/dmn-pmml-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-pmml-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ## OpenAPI (Swagger) documentation

--- a/dmn-quarkus-example/README.md
+++ b/dmn-quarkus-example/README.md
@@ -30,14 +30,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/dmn-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/dmn-tracing-quarkus/README.md
+++ b/dmn-tracing-quarkus/README.md
@@ -37,14 +37,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/dmn-tracing-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\dmn-tracing-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/flexible-process-quarkus/README.md
+++ b/flexible-process-quarkus/README.md
@@ -66,14 +66,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/flexible-process-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\flexible-process-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/pmml-quarkus-example/README.md
+++ b/pmml-quarkus-example/README.md
@@ -31,14 +31,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/pmml-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on Windows
 
 ```
 mvn clean package
-java -jar target\pmml-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-business-rules-quarkus/README.md
+++ b/process-business-rules-quarkus/README.md
@@ -76,14 +76,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-business-rules-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-business-rules-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-infinispan-persistence-quarkus/README.md
+++ b/process-infinispan-persistence-quarkus/README.md
@@ -94,14 +94,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-infinispan-persistence-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-infinispan-persistence-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-kafka-persistence-quarkus/README.md
+++ b/process-kafka-persistence-quarkus/README.md
@@ -96,14 +96,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-kafka-persistence-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-kafka-persistence-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-kafka-quickstart-quarkus/README.md
+++ b/process-kafka-quickstart-quarkus/README.md
@@ -100,14 +100,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-kafka-quickstart-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-kafka-quickstart-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-knative-quickstart-quarkus/README.md
+++ b/process-knative-quickstart-quarkus/README.md
@@ -111,14 +111,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-knative-quickstart-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-knative-quickstart-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-mongodb-persistence-quarkus/README.md
+++ b/process-mongodb-persistence-quarkus/README.md
@@ -93,14 +93,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-mongodb-persistence-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-mongodb-persistence-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-quarkus-example/README.md
+++ b/process-quarkus-example/README.md
@@ -32,14 +32,14 @@ mvn clean compile quarkus:dev
 
 ```
 mvn clean package
-java -jar target/process-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```
 mvn clean package
-java -jar target\process-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-scripts-quarkus/README.md
+++ b/process-scripts-quarkus/README.md
@@ -50,14 +50,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-scripts-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-scripts-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-service-calls-quarkus/README.md
+++ b/process-service-calls-quarkus/README.md
@@ -86,14 +86,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-service-calls-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-service-calls-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-service-rest-call-quarkus/README.md
+++ b/process-service-rest-call-quarkus/README.md
@@ -69,14 +69,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-service-rest-call-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-service-rest-call-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-usertasks-custom-lifecycle-quarkus/README.md
+++ b/process-usertasks-custom-lifecycle-quarkus/README.md
@@ -77,14 +77,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-usertasks-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-usertasks-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-usertasks-with-security-oidc-quarkus/README.md
+++ b/process-usertasks-with-security-oidc-quarkus/README.md
@@ -63,14 +63,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-usertasks-with-security-oidc-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-usertasks-with-security-oidc-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/process-usertasks-with-security-quarkus/README.md
+++ b/process-usertasks-with-security-quarkus/README.md
@@ -43,14 +43,14 @@ NOTE: With dev mode of Quarkus you can take advantage of hot reload for business
 
 ```sh
 mvn clean package
-java -jar target/process-usertasks-with-security-quarkus-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\process-usertasks-with-security-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/rules-quarkus-helloworld/README.md
+++ b/rules-quarkus-helloworld/README.md
@@ -28,14 +28,14 @@ mvn clean compile quarkus:dev
 
 ```sh
 mvn clean package
-java -jar target/rules-quarkus-helloworld-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\rules-quarkus-helloworld-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/ruleunit-quarkus-example/README.md
+++ b/ruleunit-quarkus-example/README.md
@@ -30,14 +30,14 @@ mvn clean compile quarkus:dev
 
 ```sh
 mvn clean package
-java -jar target/ruleunit-quarkus-example-runner.jar
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```sh
 mvn clean package
-java -jar target\ruleunit-quarkus-example-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/serverless-workflow-events-quarkus/README.md
+++ b/serverless-workflow-events-quarkus/README.md
@@ -47,14 +47,14 @@ mvn clean compile quarkus:dev
 
 ```text
 mvn clean package 
-java -jar target/serverless-workflow-events-quarkus-runner.jar    
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```text
 mvn clean package
-java -jar target\serverless-workflow-events-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/serverless-workflow-functions-events-quarkus/README.md
+++ b/serverless-workflow-functions-events-quarkus/README.md
@@ -134,14 +134,14 @@ _**Note:** Please make sure you have [jq](https://stedolan.github.io/jq/download
 
 ```text
 mvn clean package 
-java -jar target/serverless-workflow-functions-quarkus-runner.jar   
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```text
 mvn clean package
-java -jar target\serverless-workflow-functions-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Compile and Run using Local Native Image

--- a/serverless-workflow-functions-quarkus/README.md
+++ b/serverless-workflow-functions-quarkus/README.md
@@ -37,14 +37,14 @@ mvn clean package quarkus:dev
 
 ```text
 mvn clean package 
-java -jar target/sw-quarkus-greeting-{version}-runner.jar    
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```text
 mvn clean package
-java -jar target\sw-quarkus-greeting-{version}-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Compile and Run using Local Native Image

--- a/serverless-workflow-greeting-quarkus/README.md
+++ b/serverless-workflow-greeting-quarkus/README.md
@@ -43,14 +43,14 @@ mvn clean package quarkus:dev
 
 ```text
 mvn clean package 
-java -jar target/sw-quarkus-greeting-{version}-runner.jar    
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```text
 mvn clean package
-java -jar target\sw-quarkus-greeting-{version}-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Compile and Run using Local Native Image

--- a/serverless-workflow-service-calls-quarkus/README.md
+++ b/serverless-workflow-service-calls-quarkus/README.md
@@ -39,14 +39,14 @@ mvn clean compile quarkus:dev
 
 ```text
 mvn clean package 
-java -jar target/serverless-workflow-service-calls-quarkus-runner.jar    
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```text
 mvn clean package
-java -jar target\serverless-workflow-service-calls-quarkus-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Package and Run using Local Native Image

--- a/serverless-workflow-temperature-conversion/conversion-workflow/README.md
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/README.md
@@ -42,14 +42,14 @@ mvn clean package quarkus:dev
 
 ```bash
 mvn clean package 
-java -jar target/convertion-workflow-runner.jar    
+java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 or on windows
 
 ```bash
 mvn clean package
-java -jar target/conversion-workflow-runner.jar
+java -jar target\quarkus-app\quarkus-run.jar
 ```
 
 ### Compile and Run using Local Native Image

--- a/serverless-workflow-temperature-conversion/multiplication-service/README.md
+++ b/serverless-workflow-temperature-conversion/multiplication-service/README.md
@@ -16,8 +16,8 @@ The application can be packaged using:
 ```shell script
 ./mvn package
 ```
-It produces the `multiplication-service-{version}-runner.jar` file in the `/target` directory.
-Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/lib` directory.
+It produces the `quarkus-app/quarkus-run.jar` file in the `/target` directory.
+Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib` directory.
 
 If you want to build an _über-jar_, execute the following command:
 ```shell script

--- a/serverless-workflow-temperature-conversion/subtraction-service/README.md
+++ b/serverless-workflow-temperature-conversion/subtraction-service/README.md
@@ -16,8 +16,8 @@ The application can be packaged using:
 ```shell script
 ./mvn package
 ```
-It produces the `subtraction-service-{version}-runner.jar` file in the `/target` directory.
-Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/lib` directory.
+It produces the `quarkus-app/quarkus-run.jar` file in the `/target` directory.
+Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib` directory.
 
 If you want to build an _über-jar_, execute the following command:
 ```shell script


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4823

Now kogito-examples generates fast-jar (target/quarkus-app/quarkus-run.jar) instead of runner jar.

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
 -> sorry, this PR contains a very minor typo in dmn-event-driven-springboot/README.md as well.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>
</details>