### PR TITLE
KOGITO-4829 - Kogito-examples Quarkus Maven Plugin configuration is n…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '10', numToKeepStr: '')
-        timeout(time: 360, unit: 'MINUTES')
+        timeout(time: 600, unit: 'MINUTES')
     }
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4g'

--- a/pom.xml
+++ b/pom.xml
@@ -273,26 +273,8 @@
         <module>serverless-workflow-events-quarkus</module>
         <module>serverless-workflow-temperature-conversion</module>
       </modules>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <configuration>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
-                  <enableJni>true</enableJni>
-                  <enableAllSecurityServices>true</enableAllSecurityServices>
-                  <additionalBuildArgs>--allow-incomplete-classpath</additionalBuildArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
+
     <profile>
       <id>productized</id>
       <activation>

--- a/process-optaplanner-quarkus/src/main/resources/application.properties
+++ b/process-optaplanner-quarkus/src/main/resources/application.properties
@@ -5,3 +5,6 @@
 quarkus.optaplanner.solver.termination.spent-limit=5s
 resteasy.jaxrs.scan-packages=org.kie.kogito.**
 quarkus.resteasy.path=/rest
+
+# native image properties
+quarkus.native.additional-build-args=--allow-incomplete-classpath

--- a/process-usertasks-with-security-oidc-quarkus-with-console/src/main/resources/application.properties
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/src/main/resources/application.properties
@@ -14,9 +14,9 @@ kogito.dataindex.ws.url=ws://localhost:8180
 quarkus.native.native-image-xmx=6g
 
 quarkus.infinispan-client.server-list=localhost:11222
-quarkus.infinispan-client.auth-username=
-quarkus.infinispan-client.auth-password=
-quarkus.infinispan-client.sasl-mechanism=
+quarkus.infinispan-client.use-auth=true
+quarkus.infinispan-client.auth-username=admin
+quarkus.infinispan-client.auth-password=admin
 
 kafka.bootstrap.servers=localhost:9092
 

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -32,10 +32,6 @@
           <groupId>org.kie.kogito</groupId>
           <artifactId>knative-eventing-addon</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>io.smallrye.reactive</groupId>
-          <artifactId>smallrye-reactive-messaging-http</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
…o longer needed

[KOGITO-4829](https://issues.redhat.com/browse/KOGITO-4829)

EDIT: I noticed that the build was broken, so I decided to fix it. There were 3 modules failing:
* process-optaplanner-quarkus - needed `--allow-incomplete-classpath` property in the `application.properties` as the one from Quarkus Maven Plugin configuration stopped working
* process-usertasks-with-security-oidc-quarkus-with-console - native image tests were unable to start the application because the Infinispan credentials were missing in `application.properties` file. Native image doesn't take into account the property file in `src/test/resources` and will always use the one in `src/main/resources`. These properties can be changed during runtime, so it shouldn't be an issue if somebody wants to play with it.
* serverless-workflow-events-quarkus - tests were failing with `Fatal error:java.lang.TypeNotPresentException: Type io.smallrye.reactive.messaging.http.converters.CloudEventSerializer not present` which was caused by an excluded dependency `io.smallrye.reactive:smallrye-reactive-messaging-http`. Thanks @ricardozanini for opening my eyes as I for some reason was including `io.quarkus:quarkus-smallrye-reactive-messaging`. :laughing: 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>
</details>