### PR TITLE
[KOGITO-4958] Add Spring Boot Actuator dependency

### DIFF
--- a/decisiontable-springboot-example/pom.xml
+++ b/decisiontable-springboot-example/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/dmn-event-driven-springboot/pom.xml
+++ b/dmn-event-driven-springboot/pom.xml
@@ -33,6 +33,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/dmn-listener-springboot/pom.xml
+++ b/dmn-listener-springboot/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/dmn-pmml-springboot-example/pom.xml
+++ b/dmn-pmml-springboot-example/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/dmn-springboot-example/pom.xml
+++ b/dmn-springboot-example/pom.xml
@@ -33,6 +33,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/dmn-tracing-springboot/pom.xml
+++ b/dmn-tracing-springboot/pom.xml
@@ -33,6 +33,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/flexible-process-springboot/pom.xml
+++ b/flexible-process-springboot/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
     <!-- kogito -->
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/pmml-springboot-example/pom.xml
+++ b/pmml-springboot-example/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/process-business-rules-springboot/pom.xml
+++ b/process-business-rules-springboot/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
     <!-- kogito -->
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/process-infinispan-persistence-springboot/pom.xml
+++ b/process-infinispan-persistence-springboot/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-spring-boot-starter-remote</artifactId>
     </dependency>

--- a/process-kafka-quickstart-springboot/pom.xml
+++ b/process-kafka-quickstart-springboot/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>

--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
     </dependency>
 

--- a/process-optaplanner-springboot/pom.xml
+++ b/process-optaplanner-springboot/pom.xml
@@ -67,6 +67,11 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>

--- a/process-postgresql-persistence-springboot/pom.xml
+++ b/process-postgresql-persistence-springboot/pom.xml
@@ -37,6 +37,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-scripts-springboot/pom.xml
+++ b/process-scripts-springboot/pom.xml
@@ -37,6 +37,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-service-calls-springboot/pom.xml
+++ b/process-service-calls-springboot/pom.xml
@@ -39,6 +39,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-service-rest-call-springboot/pom.xml
+++ b/process-service-rest-call-springboot/pom.xml
@@ -37,6 +37,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-springboot-example/pom.xml
+++ b/process-springboot-example/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-api</artifactId>
     </dependency>

--- a/process-timer-springboot/pom.xml
+++ b/process-timer-springboot/pom.xml
@@ -55,6 +55,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-usertasks-springboot/pom.xml
+++ b/process-usertasks-springboot/pom.xml
@@ -39,6 +39,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>

--- a/process-usertasks-with-security-springboot/pom.xml
+++ b/process-usertasks-with-security-springboot/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
 

--- a/ruleunit-springboot-example/pom.xml
+++ b/ruleunit-springboot-example/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
     </dependency>

--- a/serverless-workflow-greeting-springboot/pom.xml
+++ b/serverless-workflow-greeting-springboot/pom.xml
@@ -30,6 +30,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/serverless-workflow-service-calls-springboot/pom.xml
+++ b/serverless-workflow-service-calls-springboot/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4958

## Description
This PR adds the Spring Boot Actuator dependency to the Spring Boot examples as the probes will now assume that the Actuator dependency is installed and use its endpoints.

## Related PR's
- [kogito-operator](https://github.com/kiegroup/kogito-operator/pull/841): [KOGITO-4898] Set probe defaults based on YAML action values

## Requirements
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
