### PR TITLE
KOGITO-4887 Bump Quarkus 1.13

### DIFF
--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -63,6 +63,13 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-api</artifactId>
     </dependency>
+
+    <!-- required for version override, see: https://issues.redhat.com/browse/KOGITO-5031 -->
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <version>${version.org.mongo.springboot}</version>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>mongodb-persistence-addon</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4887

### Bundle

- https://github.com/kiegroup/kogito-runtimes/pull/1200
- https://github.com/kiegroup/kogito-apps/pull/774
- https://github.com/kiegroup/kogito-examples/pull/667

### Highlights

- Upgrades Quarkus 1.13 to latest:
   - does not include ISPN 12 yet
   - adds a version override for MongoDB on spring boot (otherwise the version upgrade breaks)
- makes our life miserable in the process