### PR TITLE
[RHPAM-3649] Add missing dmn-event-driven modules to productized profile [1.5.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,6 @@
         <module>process-springboot-example</module>
       </modules>
     </profile>
-    
     <profile>
       <id>events</id>
       <activation>
@@ -283,6 +282,8 @@
         </property>
       </activation>
       <modules>
+        <module>dmn-event-driven-quarkus</module>
+        <module>dmn-event-driven-springboot</module>
         <module>dmn-listener-quarkus</module>
         <module>dmn-listener-springboot</module>
         <module>dmn-pmml-quarkus-example</module>
@@ -347,7 +348,7 @@
         <artifactId>swagger-annotations</artifactId>
         <version>${version.io.swagger.core.v3}</version>
       </dependency>
-      
+
       <!-- PMML -->
       <dependency>
         <groupId>org.jpmml</groupId>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHPAM-3558
master: https://github.com/kiegroup/kogito-examples/pull/684

Add the missing dmn-event-driven modules to the productized profile.