### PR TITLE
[RHPAM-3663] Fix ruleunit-springboot-example pom to comply with XSD

### DIFF
--- a/ruleunit-springboot-example/pom.xml
+++ b/ruleunit-springboot-example/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -28,8 +30,8 @@
         <scope>import</scope>
       </dependency>
     </dependencies>
-  </dependencyManagement> 
-  
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHPAM-3663
1.5.x: https://github.com/kiegroup/kogito-examples/pull/687

The ruleunit-springboot-example pom is missing the XSD schema which is causing the XSD validation error in QEs validation tooling. 

