### PR TITLE
[KOGITO-4882] Removing SmallRye HTTP Connector from examples

### DIFF
--- a/process-knative-quickstart-quarkus/README.md
+++ b/process-knative-quickstart-quarkus/README.md
@@ -164,23 +164,22 @@ Then run the application with:
 ```shell script
 $ K_SINK=http://localhost:8181 mvn clean quarkus:dev
 
+2021-05-18 14:50:47,574 INFO  [org.kie.kog.cod.api.uti.AddonsConfigDiscovery] (build-24) Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=false, usePrometheusMonitoring=false, useCloudEvents=true, useExplainability=false, useProcessSVG=false}
+2021-05-18 14:50:47,777 INFO  [org.kie.kog.cod.cor.uti.ApplicationGeneratorDiscovery] (build-24) Generator discovery performed, found [openapispecs, processes, rules, decisions, predictions]
+2021-05-18 14:50:48,726 INFO  [org.kie.kog.cod.api.uti.AddonsConfigDiscovery] (build-31) Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=false, usePrometheusMonitoring=false, useCloudEvents=true, useExplainability=false, useProcessSVG=false}
+2021-05-18 14:50:48,730 INFO  [org.kie.kog.qua.com.dep.KogitoQuarkusResourceUtils] (build-31) No Java source to compile
 __  ____  __  _____   ___  __ ____  ______ 
  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
-2020-08-04 17:50:08,685 INFO  [org.kie.kog.cod.pro.ProcessCodegen] (build-24) Knative Eventing addon enabled, generating CloudEvent HTTP listener
-2020-08-04 17:50:11,350 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00208: Deployment done... start processing
-2020-08-04 17:50:11,353 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00226: Found incoming connectors: [smallrye-http]
-2020-08-04 17:50:11,355 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00227: Found outgoing connectors: [smallrye-http]
-2020-08-04 17:50:11,355 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00229: Channel manager initializing...
-2020-08-04 17:50:11,384 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00209: Initializing mediators
-2020-08-04 17:50:11,386 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00215: Connecting mediators
-2020-08-04 17:50:11,386 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00216: Attempt to resolve org.kie.kogito.test.TravelersMessageConsumer_3#consume
-2020-08-04 17:50:11,387 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00217: Connecting org.kie.kogito.test.TravelersMessageConsumer_3#consume to `[travellers]` (org.eclipse.microprofile.reactive.streams.operators.core.PublisherBuilderImpl@fb1ed7a)
-2020-08-04 17:50:11,421 INFO  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00222: Connecting emitter to sink processedtravellers
-2020-08-04 17:50:11,510 INFO  [io.quarkus] (Quarkus Main Thread) process-knative-quickstart-quarkus 8.0.0-SNAPSHOT on JVM (powered by Quarkus 1.6.0.Final) started in 4.222s. Listening on: http://0.0.0.0:8080
-2020-08-04 17:50:11,510 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2020-08-04 17:50:11,510 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, kogito, mutiny, resteasy, resteasy-jackson, smallrye-context-propagation, smallrye-openapi, smallrye-reactive-messaging, swagger-ui, vertx]
+2021-05-18 14:50:50,046 WARN  [io.sma.rea.mes.provider] (Quarkus Main Thread) SRMSG00207: Some components are not connected to either downstream consumers or upstream producers:
+	- SubscriberMethod{method:'org.kie.kogito.addon.cloudevents.quarkus.QuarkusCloudEventPublisher#onEvent', incoming:'kogito_incoming_stream'} has no upstream
+
+2021-05-18 14:50:50,111 INFO  [org.kie.kog.add.clo.qua.QuarkusKogitoExtensionInitializer] (Quarkus Main Thread) Registered Kogito CloudEvent extension
+2021-05-18 14:50:50,114 INFO  [org.kie.kog.ser.eve.imp.AbstractMessageConsumer] (Quarkus Main Thread) Consumer for class org.acme.travel.Traveller started.
+2021-05-18 14:50:50,164 INFO  [io.quarkus] (Quarkus Main Thread) process-knative-quickstart-quarkus 2.0.0-SNAPSHOT on JVM (powered by Quarkus 1.13.3.Final) started in 3.118s. Listening on: http://localhost:8080
+2021-05-18 14:50:50,164 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
+2021-05-18 14:50:50,164 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, kogito-decisions, kogito-predictions, kogito-processes, kogito-rules, mutiny, rest-client, rest-client-jackson, resteasy, resteasy-jackson, servlet, smallrye-context-propagation, smallrye-health, smallrye-openapi, smallrye-reactive-messaging, swagger-ui, vertx, vertx-web]
 ``` 
 
 Now send a message to the application on 8080 port using the [cloud event format](https://github.com/cloudevents/spec) with `curl`:
@@ -203,14 +202,14 @@ You should see an output like this one in the running container terminal:
 Validation: valid
 Context Attributes,
   specversion: 1.0
-  type: process.travelers.processedtravellers
-  source: /process/Travelers/57faaf75-959e-4b09-a6c8-b53ee33fb2f0
-  id: e8bddf03-e05c-4884-bd82-6fb1acc6e805
-  time: 2020-08-04T20:55:07.215083Z
+  type: processedtravellers
+  source: /process/Travelers
+  id: f37c3856-3ee4-47ed-8daf-d81ff6c8d695
+  time: 2021-05-18T17:51:50.056553Z
 Extensions,
-  kogitoprocessid: Travelers
-  kogitoprocessinstanceid: 57faaf75-959e-4b09-a6c8-b53ee33fb2f0
-  kogitoprocessinstancestate: 1
+  kogitoprocid: Travelers
+  kogitoprocinstanceid: c70a8abc-eaa6-4be9-85e9-2ebf9bcb101b
+  kogitousertaskist: 1
 Data,
   {"firstName":"Jan","lastName":"Kowalski","email":"jan.kowalski@example.com","nationality":"Polish","processed":true}
 ```

--- a/process-knative-quickstart-quarkus/src/main/resources/application.properties
+++ b/process-knative-quickstart-quarkus/src/main/resources/application.properties
@@ -3,14 +3,8 @@
 
 quarkus.swagger-ui.always-include=true
 
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK}
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g
-
-# avoid Smallrye CloudEvent Serializers to be initialized on build time. It will try to initialize CloudEvents Serializer that's not been used.
-# We use CloudEvents SDK directly instead. By turning `--allow-incomplete-classpath` option, the native image will be built successfully and since
-# this branch will never be called in runtime, no errors would be thrown.
-# See: https://issues.redhat.com/browse/KOGITO-3623
-quarkus.native.additional-build-args=--allow-incomplete-classpath

--- a/process-knative-quickstart-quarkus/src/test/resources/application.properties
+++ b/process-knative-quickstart-quarkus/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.http.test-port=8282
 quarkus.log.level=INFO
 
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://0.0.0.0:8181

--- a/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
@@ -3,7 +3,6 @@
 
 quarkus.swagger-ui.always-include=true
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
-mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http
 quarkus.log.category."org.acme".level=DEBUG
 kogito.sw.functions.StoreNewPatient.host=localhost
 kogito.sw.functions.StoreNewPatient.port=8080

--- a/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
@@ -4,10 +4,10 @@ quarkus.swagger-ui.always-include=true
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/url=${GITHUB_SERVICE_URI}
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/scope=javax.inject.Singleton
 
-mp.messaging.outgoing.pr_verified.connector=smallrye-http
+mp.messaging.outgoing.pr_verified.connector=quarkus-http
 mp.messaging.outgoing.pr_verified.url=${K_SINK}
 
-mp.messaging.outgoing.checker_workflow_frontend.connector=smallrye-http
+mp.messaging.outgoing.checker_workflow_frontend.connector=quarkus-http
 mp.messaging.outgoing.checker_workflow_frontend.url=${K_SINK}
-mp.messaging.outgoing.checker_workflow_backend.connector=smallrye-http
+mp.messaging.outgoing.checker_workflow_backend.connector=quarkus-http
 mp.messaging.outgoing.checker_workflow_backend.url=${K_SINK}

--- a/serverless-workflow-github-showcase/pr-checker-workflow/src/test/resources/application.properties
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/src/test/resources/application.properties
@@ -2,15 +2,15 @@ quarkus.log.category."org.kogito".level=INFO
 quarkus.log.category."org.kie.kogito.app".level=INFO
 
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/url=
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://localhost:9090/
 
 # our sink server will sink these messages. See: org.kogito.examples.sw.github.workflow.MessageSinkServer
-mp.messaging.outgoing.pr_verified.connector=smallrye-http
+mp.messaging.outgoing.pr_verified.connector=quarkus-http
 mp.messaging.outgoing.pr_verified.url=http://localhost:8181/
 
-mp.messaging.outgoing.checker_workflow_frontend.connector=smallrye-http
+mp.messaging.outgoing.checker_workflow_frontend.connector=quarkus-http
 mp.messaging.outgoing.checker_workflow_frontend.url=http://localhost:8181/
 
-mp.messaging.outgoing.checker_workflow_backend.connector=smallrye-http
+mp.messaging.outgoing.checker_workflow_backend.connector=quarkus-http
 mp.messaging.outgoing.checker_workflow_backend.url=http://localhost:8181/

--- a/serverless-workflow-order-processing/src/main/resources/application.properties
+++ b/serverless-workflow-order-processing/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.log.level=INFO
 
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK}

--- a/serverless-workflow-order-processing/src/test/resources/application.properties
+++ b/serverless-workflow-order-processing/src/test/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.log.level=INFO
 
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://0.0.0.0:8181


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-4882

In this PR we removed the deprecated SmallRye HTTP connector from our examples.

Depends on https://github.com/kiegroup/kogito-runtimes/pull/1315

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>