### PR TITLE
[KOGITO-5302] Disable fail on empty beans

### DIFF
--- a/process-quarkus-example/src/main/java/org/kie/kogito/examples/CustomizeObjectMapper.java
+++ b/process-quarkus-example/src/main/java/org/kie/kogito/examples/CustomizeObjectMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples;
+
+import javax.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class CustomizeObjectMapper implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    }
+
+}


### PR DESCRIPTION
Just a quick fix for the example to work on native mode. 
We should consider to have a global customizer class where we set up that to false to all projects, but I let @danielezonca to think about this ;)