### PR TITLE
[KOGITO-5511] - (Examples) Downgrade SpringBoot to 2.3.x

### DIFF
--- a/process-usertasks-springboot-with-console/src/main/java/org/kie/kogito/tests/CorsConfig.java
+++ b/process-usertasks-springboot-with-console/src/main/java/org/kie/kogito/tests/CorsConfig.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.tests;
 
-import java.util.Arrays;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -32,7 +30,9 @@ public class CorsConfig {
 
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOriginPatterns(Arrays.asList("http://*:8080", "http://*:8280", "http://*:8380"));
+        // TODO: KOGITO-5455 / KOGITO-5511 can be reverted back once we upgrade to SB 2.4.x
+        config.addAllowedOrigin("*");
+        //config.setAllowedOriginPatterns(Arrays.asList("http://*:8080", "http://*:8280", "http://*:8380"));
         config.addAllowedHeader("*");
         config.addAllowedMethod("OPTIONS");
         config.addAllowedMethod("GET");

--- a/process-usertasks-with-security-oidc-springboot-with-console/src/main/java/org/kie/kogito/springboot/CorsConfig.java
+++ b/process-usertasks-with-security-oidc-springboot-with-console/src/main/java/org/kie/kogito/springboot/CorsConfig.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.springboot;
 
-import java.util.Arrays;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -32,7 +30,9 @@ public class CorsConfig {
 
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOriginPatterns(Arrays.asList("http://*:8080", "http://*:8280", "http://*:8380", "http://*:8480"));
+        // TODO: KOGITO-5455 / KOGITO-5511 can be reverted back once we upgrade to SB 2.4.x
+        config.addAllowedOrigin("*");
+        //config.setAllowedOriginPatterns(Arrays.asList("http://*:8080", "http://*:8280", "http://*:8380", "http://*:8480"));
         config.addAllowedHeader("*");
         config.addAllowedMethod("OPTIONS");
         config.addAllowedMethod("GET");
@@ -44,5 +44,4 @@ public class CorsConfig {
 
         return new CorsFilter(source);
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-5455 and https://issues.redhat.com/browse/KOGITO-5511

The comment in KOGITO-5455 explains this change. We need to revert back since SB 2.3.x depends on Spring Web 5.2.x, which does not have the method used in the bug fixing.

Related PR:

- https://github.com/kiegroup/kogito-runtimes/pull/1440

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `master` branch!**

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>