### PR TITLE
KOGITO-5672 Implement GHA for open github issues for Zulip bot

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,23 @@
+name: Workflows to notify the team about github issues
+
+on:
+  issues:
+    types: [opened, reopened]
+jobs:
+  message:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: 'echo ${{ github.event.issue.title }}'
+    - name: Send a stream message
+      uses: zulip/github-actions-zulip/send-message@e71e15b429b0e79cc7b63e4e3dad0146443fab6f
+      env:
+        CONTENT: "I have detected a new issue on github:\n${{ github.event.issue.body }}\n-- This is an automatically relayed message. Don't reply to me directly, I'm just a bot and I don't understand human language (yet). You can reply using this link: \n${{ github.event.issue.html_url }}"
+      with:
+        api-key: ${{ secrets.ZULIP_BOT_SECRET }}
+        email: 'github-kogito-bot@kie.zulipchat.com'
+        organization-url: 'https://kie.zulipchat.com'
+        to: 'kogito'
+        type: 'stream'
+        topic: 'GitHub Issues - ${{ github.event.issue.title }}'
+        content: ${{ env.CONTENT }}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5672

followup
kiegroup/kogito-runtimes#1511
https://github.com/kiegroup/kogito-apps/pull/978

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>