### PR TITLE
KOGITO-5267 Fix quarkus-maven-plugin version in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-maven-plugin</artifactId>
-          <version>${quarkus-plugin.version}</version>
+          <version>${version.io.quarkus}</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fix the quarkus-maven-plugin version in the root pom that mistakenly references wrong version property. I already noticed this in my WIP follow-up PR and was surprised the build did not fail for it but splitting this change out to fix compilation error.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `main` branch!**

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>