### PR TITLE
[1.11.x] KOGITO-5790: Process user tasks with timer example using wrong jobs service image

### DIFF
--- a/process-usertasks-quarkus-with-console/docker-compose/docker-compose.yml
+++ b/process-usertasks-quarkus-with-console/docker-compose/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     volumes:
       - ./persistence/:/home/kogito/data/protobufs/
     environment:
+      QUARKUS_INFINISPAN_CLIENT_USE_AUTH: "false"
       QUARKUS_INFINISPAN_CLIENT_SERVER_LIST: infinispan:11222
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KOGITO_DATA_INDEX_PROPS: -Dkogito.protobuf.folder=/home/kogito/data/protobufs/

--- a/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose.yml
+++ b/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose.yml
@@ -81,13 +81,14 @@ services:
       - ./persistence/:/home/kogito/data/protobufs/
     environment:
       QUARKUS_INFINISPAN_CLIENT_SERVER_LIST: infinispan:11222
+      QUARKUS_INFINISPAN_CLIENT_USE_AUTH: "false"
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KOGITO_DATA_INDEX_PROPS: -Dkogito.protobuf.folder=/home/kogito/data/protobufs/
 
   jobs-service:
     container_name: jobs-service
     network_mode: "host"
-    image: quay.io/kiegroup/kogito-jobs-service:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-jobs-service-infinispan:${KOGITO_VERSION}
     depends_on:
       kafka:
         condition: service_started
@@ -95,7 +96,8 @@ services:
         condition: service_healthy
       data-index:
         condition: service_started
-    environment: 
+    environment:
+      QUARKUS_INFINISPAN_CLIENT_USE_AUTH: "false"
       ENABLE_EVENTS: "true"
       KOGITO_JOBS_PROPS: -Dquarkus-profile=events-support -D%events-support.quarkus.http.port=8580 -D%events-support.kafka.bootstrap.servers=localhost:9092
                          -D%events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.bootstrap.servers=localhost:9092


### PR DESCRIPTION
backport of https://github.com/kiegroup/kogito-examples/pull/870

Also adding missing config on `process-usertasks-quarkus-with-console.`


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `main` branch!**

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>