### PR TITLE
KOGITO-5926 - Extend test coverage for process monitoring

### DIFF
--- a/process-monitoring-quarkus/pom.xml
+++ b/process-monitoring-quarkus/pom.xml
@@ -49,6 +49,15 @@
 
   <build>
     <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/process-monitoring-quarkus/src/main/java/org/kie/kogito/examples/quarkus/CalculationService.java
+++ b/process-monitoring-quarkus/src/main/java/org/kie/kogito/examples/quarkus/CalculationService.java
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.kie.kogito.examples.quarkus;
 
-package org.kie.kogito.examples;
+import java.util.Random;
 
-import io.quarkus.test.junit.NativeImageTest;
+import javax.enterprise.context.ApplicationScoped;
 
-@NativeImageTest
-public class NativeDashboardGenerationIT extends DashboardGenerationTest {
+import org.kie.kogito.examples.quarkus.demo.Order;
 
-    // Execute the same tests but in native mode.
+@ApplicationScoped
+public class CalculationService {
+
+    private Random random = new Random();
+
+    public Order calculateTotal(Order order) {
+        order.setTotal(random.nextDouble());
+
+        return order;
+    }
 }

--- a/process-monitoring-quarkus/src/main/java/org/kie/kogito/examples/quarkus/demo/Order.java
+++ b/process-monitoring-quarkus/src/main/java/org/kie/kogito/examples/quarkus/demo/Order.java
@@ -13,45 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.examples.demo;
+package org.kie.kogito.examples.quarkus.demo;
 
 public class Order implements java.io.Serializable {
 
     static final long serialVersionUID = 1L;
 
-    private java.lang.String orderNumber;
-    private java.lang.Boolean shipped;
-    private java.lang.Double total;
+    private String orderNumber;
+    private Boolean shipped;
+    private Double total;
 
     public Order() {
     }
 
-    public java.lang.String getOrderNumber() {
+    public String getOrderNumber() {
         return this.orderNumber;
     }
 
-    public void setOrderNumber(java.lang.String orderNumber) {
+    public void setOrderNumber(String orderNumber) {
         this.orderNumber = orderNumber;
     }
 
-    public java.lang.Boolean isShipped() {
+    public Boolean isShipped() {
         return this.shipped;
     }
 
-    public void setShipped(java.lang.Boolean shipped) {
+    public void setShipped(Boolean shipped) {
         this.shipped = shipped;
     }
 
-    public java.lang.Double getTotal() {
+    public Double getTotal() {
         return this.total;
     }
 
-    public void setTotal(java.lang.Double total) {
+    public void setTotal(Double total) {
         this.total = total;
     }
 
-    public Order(java.lang.String orderNumber, java.lang.Boolean shipped,
-            java.lang.Double total) {
+    public Order(String orderNumber, Boolean shipped,
+            Double total) {
         this.orderNumber = orderNumber;
         this.shipped = shipped;
         this.total = total;
@@ -60,5 +60,4 @@ public class Order implements java.io.Serializable {
     public String toString() {
         return "Order[" + this.orderNumber + "]";
     }
-
 }

--- a/process-monitoring-quarkus/src/main/resources/org/kie/kogito/examples/quarkus/orderItems.bpmn2
+++ b/process-monitoring-quarkus/src/main/resources/org/kie/kogito/examples/quarkus/orderItems.bpmn2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- origin at X=0.0 Y=0.0 -->
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_TQSqoEcJEemyodG9iPy-Bw" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
   <bpmn2:itemDefinition id="_itemItem" isCollection="false" structureRef="String"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_SkippableInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_PriorityInputXItem" isCollection="false" structureRef="Object"/>
@@ -11,9 +11,9 @@
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_TaskNameInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_GroupIdInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_ContentInputXItem" isCollection="false" structureRef="Object"/>
-  <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_itemOutputXItem" isCollection="false" structureRef="String"/>
-  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
   <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="ItemDefinition_3" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="ItemDefinition_4" isCollection="false" structureRef="Object"/>
@@ -31,15 +31,15 @@
   <bpmn2:itemDefinition id="ItemDefinition_16" isCollection="false" structureRef="java.lang.Boolean"/>
   <bpmn2:message id="Message_1" itemRef="ItemDefinition_1" name="Message 1"/>
   <bpmn2:message id="Message_2" itemRef="ItemDefinition_1" name="Message 2"/>
-  <bpmn2:interface id="Interface_1" implementationRef="org.kie.kogito.examples.CalculationService" name="CalculationService">
+  <bpmn2:interface id="Interface_1" implementationRef="org.kie.kogito.examples.quarkus.CalculationService" name="CalculationService">
     <bpmn2:operation id="Operation_1" name="calculateTotal">
       <bpmn2:inMessageRef>Message_1</bpmn2:inMessageRef>
       <bpmn2:outMessageRef>Message_2</bpmn2:outMessageRef>
     </bpmn2:operation>
   </bpmn2:interface>
-  <bpmn2:process id="demo.orderItems" drools:packageName="org.kie.kogito.examples" drools:version="1.0" drools:adHoc="false" name="orderItems" isExecutable="true" processType="Private">
+  <bpmn2:process id="demo.orderItems" drools:packageName="org.kie.kogito.examples.quarkus" drools:version="1.0" drools:adHoc="false" name="orderItems" isExecutable="true" processType="Private">
     <bpmn2:extensionElements>
-      <drools:import name="org.kie.kogito.examples.demo.Order"/>
+      <drools:import name="org.kie.kogito.examples.quarkus.demo.Order"/>
     </bpmn2:extensionElements>
     <bpmn2:property id="order" itemSubjectRef="_orderItem" name="order"/>
     <bpmn2:property id="item" itemSubjectRef="_itemItem" name="item"/>

--- a/process-monitoring-quarkus/src/main/resources/org/kie/kogito/examples/quarkus/orders.bpmn2
+++ b/process-monitoring-quarkus/src/main/resources/org/kie/kogito/examples/quarkus/orders.bpmn2
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- origin at X=0.0 Y=0.0 -->
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_gfw8oEcJEemyodG9iPy-Bw" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
   <bpmn2:itemDefinition id="_approverItem" isCollection="false" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
-  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
-  <bpmn2:process id="demo.orders" drools:packageName="org.kie.kogito.examples" drools:version="1.0" drools:adHoc="false" name="orders" isExecutable="true">
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" isCollection="false" structureRef="org.kie.kogito.examples.quarkus.demo.Order"/>
+  <bpmn2:process id="demo.orders" drools:packageName="org.kie.kogito.examples.quarkus" drools:version="1.0" drools:adHoc="false" name="orders" isExecutable="true">
     <bpmn2:documentation id="_gfw8oUcJEemyodG9iPy-Bw"><![CDATA[Deals with orders created by customer]]></bpmn2:documentation>
     <bpmn2:property id="order" itemSubjectRef="_orderItem" name="order"/>
     <bpmn2:property id="approver" itemSubjectRef="_approverItem" name="approver"/>
@@ -45,8 +45,8 @@
       <bpmn2:incoming>_58684613-0155-48B2-8746-7675AFF24439</bpmn2:incoming>
       <bpmn2:outgoing>_8216C810-34D8-4BFA-B814-1AA01907810F</bpmn2:outgoing>
       <bpmn2:ioSpecification id="_gfw8okcJEemyodG9iPy-Bw">
-        <bpmn2:dataInput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" name="order"/>
-        <bpmn2:dataOutput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" name="order"/>
+        <bpmn2:dataInput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX" drools:dtype="org.kie.kogito.examples.quarkus.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" name="order"/>
+        <bpmn2:dataOutput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX" drools:dtype="org.kie.kogito.examples.quarkus.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" name="order"/>
         <bpmn2:inputSet id="_gfw8o0cJEemyodG9iPy-Bw">
           <bpmn2:dataInputRefs>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>

--- a/process-monitoring-quarkus/src/test/filtered-resources/project.properties
+++ b/process-monitoring-quarkus/src/test/filtered-resources/project.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+project.version=${project.version}
+project.artifactId=${project.artifactId}

--- a/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/DashboardGenerationTest.java
+++ b/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/DashboardGenerationTest.java
@@ -14,35 +14,20 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.examples;
+package org.kie.kogito.examples.quarkus;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import io.restassured.RestAssured;
+import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = DemoApplication.class)
+@QuarkusTest
 public class DashboardGenerationTest {
-
-    // restassured needs to know the random port created for test
-    @LocalServerPort
-    int port;
-
-    @BeforeEach
-    public void setUp() {
-        RestAssured.port = port;
-    }
 
     @Test
     @SuppressWarnings("unchecked")
@@ -50,5 +35,8 @@ public class DashboardGenerationTest {
         List<String> dashboards = given().contentType(ContentType.JSON).accept(ContentType.JSON)
                 .when().get("/monitoring/dashboards/list.json").as(List.class);
         Assertions.assertEquals(3, dashboards.size());
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("demo.orderItems.json")));
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("Global.json")));
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("demo.orders.json")));
     }
 }

--- a/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/NativeDashboardGenerationIT.java
+++ b/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/NativeDashboardGenerationIT.java
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.examples;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+package org.kie.kogito.examples.quarkus;
 
-@SpringBootApplication(scanBasePackages = { "org.kie.kogito.**" })
-public class DemoApplication {
+import io.quarkus.test.junit.NativeImageTest;
 
-    public static void main(String[] args) {
-        SpringApplication.run(DemoApplication.class, args);
-    }
+@NativeImageTest
+public class NativeDashboardGenerationIT extends DashboardGenerationTest {
+
+    // Execute the same tests but in native mode.
 }

--- a/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/ProcessMetricsTest.java
+++ b/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/ProcessMetricsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.examples.quarkus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.Model;
+import org.kie.kogito.examples.quarkus.demo.Order;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.ProcessInstanceReadMode;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+public class ProcessMetricsTest {
+
+    private static final String PROJECT_VERSION = ProjectMetadataProvider.getProjectVersion();
+    private static final String PROJECT_ARTIFACT_ID = ProjectMetadataProvider.getProjectArtifactId();
+
+    @Inject
+    @Named("demo.orders")
+    Process<? extends Model> orderProcess;
+
+    @Inject
+    @Named("demo.orderItems")
+    Process<? extends Model> orderItemsProcess;
+
+    @BeforeEach
+    public void setup() {
+        // abort all instances after each test
+        // as other tests might have added instances
+        // needed until Quarkus implements @DirtiesContext similar to springboot
+        // see https://github.com/quarkusio/quarkus/pull/2866
+        orderProcess.instances().values(ProcessInstanceReadMode.MUTABLE).forEach(pi -> pi.abort());
+        orderItemsProcess.instances().values(ProcessInstanceReadMode.MUTABLE).forEach(pi -> pi.abort());
+    }
+
+    @Test
+    public void testProcessMetricsQuarkus() {
+        assertNotNull(orderProcess);
+
+        Model m = orderProcess.createModel();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("approver", "john");
+        parameters.put("order", new Order("12345", false, 0.0));
+        m.fromMap(parameters);
+
+        ProcessInstance<?> processInstance = orderProcess.createInstance(m);
+        processInstance.start();
+
+        given()
+                .when()
+                .get("/metrics")
+                .then()
+                .statusCode(200)
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orders\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_started_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orderItems\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orders\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orderItems\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_work_item_duration_seconds_max{artifactId=\"%s\",name=\"org.kie.kogito.examples.quarkus.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_work_item_duration_seconds_count{artifactId=\"%s\",name=\"org.kie.kogito.examples.quarkus.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_work_item_duration_seconds_sum{artifactId=\"%s\",name=\"org.kie.kogito.examples.quarkus.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)));
+    }
+}

--- a/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/ProjectMetadataProvider.java
+++ b/process-monitoring-quarkus/src/test/java/org/kie/kogito/examples/quarkus/ProjectMetadataProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples.quarkus;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class ProjectMetadataProvider {
+
+    private static final Properties props = new Properties();
+
+    private static final String projectVersion;
+    private static final String projectArtifactId;
+
+    static {
+        String propertyFileName = "project.properties";
+        try {
+            props.load(ProjectMetadataProvider.class.getClassLoader().getResourceAsStream(propertyFileName));
+            projectVersion = props.getProperty("project.version");
+            projectArtifactId = props.getProperty("project.artifactId");
+        } catch (IOException e) {
+            throw new IllegalStateException("Impossible to retrieve property file " + propertyFileName, e);
+        }
+        if (projectVersion == null || projectArtifactId == null || projectVersion.startsWith("${") || projectArtifactId.startsWith("${")) {
+            throw new IllegalStateException("The projectVersion and/or the projectArtifactId maven properties are not configured properly.");
+        }
+    }
+
+    public static String getProjectVersion() {
+        return projectVersion;
+    }
+
+    public static String getProjectArtifactId() {
+        return projectArtifactId;
+    }
+}

--- a/process-monitoring-quarkus/src/test/resources/application.properties
+++ b/process-monitoring-quarkus/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+# Quarkus
+quarkus.http.test-port=0

--- a/process-monitoring-springboot/pom.xml
+++ b/process-monitoring-springboot/pom.xml
@@ -49,6 +49,15 @@
 
   <build>
     <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.kie.kogito</groupId>

--- a/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/CalculationService.java
+++ b/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/CalculationService.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.examples;
+package org.kie.kogito.examples.springboot;
 
 import java.util.Random;
 
-import org.kie.kogito.examples.demo.Order;
+import org.kie.kogito.examples.springboot.demo.Order;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/DemoApplication.java
+++ b/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/DemoApplication.java
@@ -13,22 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.examples;
+package org.kie.kogito.examples.springboot;
 
-import java.util.Random;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import javax.enterprise.context.ApplicationScoped;
+@SpringBootApplication(scanBasePackages = { "org.kie.kogito.**" })
+public class DemoApplication {
 
-import org.kie.kogito.examples.demo.Order;
-
-@ApplicationScoped
-public class CalculationService {
-
-    private Random random = new Random();
-
-    public Order calculateTotal(Order order) {
-        order.setTotal(random.nextDouble());
-
-        return order;
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
     }
 }

--- a/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/demo/Order.java
+++ b/process-monitoring-springboot/src/main/java/org/kie/kogito/examples/springboot/demo/Order.java
@@ -13,45 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.examples.demo;
+package org.kie.kogito.examples.springboot.demo;
 
 public class Order implements java.io.Serializable {
 
     static final long serialVersionUID = 1L;
 
-    private String orderNumber;
-    private Boolean shipped;
-    private Double total;
+    private java.lang.String orderNumber;
+    private java.lang.Boolean shipped;
+    private java.lang.Double total;
 
     public Order() {
     }
 
-    public String getOrderNumber() {
+    public java.lang.String getOrderNumber() {
         return this.orderNumber;
     }
 
-    public void setOrderNumber(String orderNumber) {
+    public void setOrderNumber(java.lang.String orderNumber) {
         this.orderNumber = orderNumber;
     }
 
-    public Boolean isShipped() {
+    public java.lang.Boolean isShipped() {
         return this.shipped;
     }
 
-    public void setShipped(Boolean shipped) {
+    public void setShipped(java.lang.Boolean shipped) {
         this.shipped = shipped;
     }
 
-    public Double getTotal() {
+    public java.lang.Double getTotal() {
         return this.total;
     }
 
-    public void setTotal(Double total) {
+    public void setTotal(java.lang.Double total) {
         this.total = total;
     }
 
-    public Order(String orderNumber, Boolean shipped,
-            Double total) {
+    public Order(java.lang.String orderNumber, java.lang.Boolean shipped,
+            java.lang.Double total) {
         this.orderNumber = orderNumber;
         this.shipped = shipped;
         this.total = total;
@@ -60,4 +60,5 @@ public class Order implements java.io.Serializable {
     public String toString() {
         return "Order[" + this.orderNumber + "]";
     }
+
 }

--- a/process-monitoring-springboot/src/main/resources/org/kie/kogito/examples/springboot/orderItems.bpmn2
+++ b/process-monitoring-springboot/src/main/resources/org/kie/kogito/examples/springboot/orderItems.bpmn2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- origin at X=0.0 Y=0.0 -->
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_TQSqoEcJEemyodG9iPy-Bw" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
   <bpmn2:itemDefinition id="_itemItem" isCollection="false" structureRef="String"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_SkippableInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_PriorityInputXItem" isCollection="false" structureRef="Object"/>
@@ -11,9 +11,9 @@
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_TaskNameInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_GroupIdInputXItem" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_ContentInputXItem" isCollection="false" structureRef="Object"/>
-  <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
   <bpmn2:itemDefinition id="__30B30BDA-D41B-4E4A-8037-F6BAF9EF29DC_itemOutputXItem" isCollection="false" structureRef="String"/>
-  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
   <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="ItemDefinition_3" isCollection="false" structureRef="Object"/>
   <bpmn2:itemDefinition id="ItemDefinition_4" isCollection="false" structureRef="Object"/>
@@ -31,15 +31,15 @@
   <bpmn2:itemDefinition id="ItemDefinition_16" isCollection="false" structureRef="java.lang.Boolean"/>
   <bpmn2:message id="Message_1" itemRef="ItemDefinition_1" name="Message 1"/>
   <bpmn2:message id="Message_2" itemRef="ItemDefinition_1" name="Message 2"/>
-  <bpmn2:interface id="Interface_1" implementationRef="org.kie.kogito.examples.CalculationService" name="CalculationService">
+  <bpmn2:interface id="Interface_1" implementationRef="org.kie.kogito.examples.springboot.CalculationService" name="CalculationService">
     <bpmn2:operation id="Operation_1" name="calculateTotal">
       <bpmn2:inMessageRef>Message_1</bpmn2:inMessageRef>
       <bpmn2:outMessageRef>Message_2</bpmn2:outMessageRef>
     </bpmn2:operation>
   </bpmn2:interface>
-  <bpmn2:process id="demo.orderItems" drools:packageName="org.kie.kogito.examples" drools:version="1.0" drools:adHoc="false" name="orderItems" isExecutable="true" processType="Private">
+  <bpmn2:process id="demo.orderItems" drools:packageName="org.kie.kogito.examples.springboot" drools:version="1.0" drools:adHoc="false" name="orderItems" isExecutable="true" processType="Private">
     <bpmn2:extensionElements>
-      <drools:import name="org.kie.kogito.examples.demo.Order"/>
+      <drools:import name="org.kie.kogito.examples.springboot.demo.Order"/>
     </bpmn2:extensionElements>
     <bpmn2:property id="order" itemSubjectRef="_orderItem" name="order"/>
     <bpmn2:property id="item" itemSubjectRef="_itemItem" name="item"/>

--- a/process-monitoring-springboot/src/main/resources/org/kie/kogito/examples/springboot/orders.bpmn2
+++ b/process-monitoring-springboot/src/main/resources/org/kie/kogito/examples/springboot/orders.bpmn2
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_gfw8oEcJEemyodG9iPy-Bw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:itemDefinition id="_orderItem" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="_orderItem" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
   <bpmn2:itemDefinition id="_approverItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" structureRef="org.kie.kogito.examples.demo.Order"/>
-  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" structureRef="org.kie.kogito.examples.demo.Order"/>
-  <bpmn2:process id="demo.orders" drools:packageName="org.kie.kogito.examples" drools:version="1.0" drools:adHoc="false" name="orders" isExecutable="true">
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" structureRef="org.kie.kogito.examples.springboot.demo.Order"/>
+  <bpmn2:process id="demo.orders" drools:packageName="org.kie.kogito.examples.springboot" drools:version="1.0" drools:adHoc="false" name="orders" isExecutable="true">
     <bpmn2:documentation id="_gfw8oUcJEemyodG9iPy-Bw"><![CDATA[Deals with orders created by customer]]></bpmn2:documentation>
     <bpmn2:property id="order" itemSubjectRef="_orderItem" name="order"/>
     <bpmn2:property id="approver" itemSubjectRef="_approverItem" name="approver"/>
@@ -39,8 +39,8 @@
       <bpmn2:incoming>_58684613-0155-48B2-8746-7675AFF24439</bpmn2:incoming>
       <bpmn2:outgoing>_8216C810-34D8-4BFA-B814-1AA01907810F</bpmn2:outgoing>
       <bpmn2:ioSpecification id="_gfw8okcJEemyodG9iPy-Bw">
-        <bpmn2:dataInput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" name="order"/>
-        <bpmn2:dataOutput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" name="order"/>
+        <bpmn2:dataInput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX" drools:dtype="org.kie.kogito.examples.springboot.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" name="order"/>
+        <bpmn2:dataOutput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX" drools:dtype="org.kie.kogito.examples.springboot.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" name="order"/>
         <bpmn2:inputSet id="_gfw8o0cJEemyodG9iPy-Bw">
           <bpmn2:dataInputRefs>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>

--- a/process-monitoring-springboot/src/test/filtered-resources/project.properties
+++ b/process-monitoring-springboot/src/test/filtered-resources/project.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+project.version=${project.version}
+project.artifactId=${project.artifactId}

--- a/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/DashboardGenerationTest.java
+++ b/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/DashboardGenerationTest.java
@@ -14,20 +14,35 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.examples;
+package org.kie.kogito.examples.springboot;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 
-@QuarkusTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = DemoApplication.class)
 public class DashboardGenerationTest {
+
+    // restassured needs to know the random port created for test
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
 
     @Test
     @SuppressWarnings("unchecked")
@@ -35,5 +50,8 @@ public class DashboardGenerationTest {
         List<String> dashboards = given().contentType(ContentType.JSON).accept(ContentType.JSON)
                 .when().get("/monitoring/dashboards/list.json").as(List.class);
         Assertions.assertEquals(3, dashboards.size());
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("demo.orderItems.json")));
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("Global.json")));
+        Assertions.assertTrue(dashboards.stream().anyMatch(s -> s.contains("demo.orders.json")));
     }
 }

--- a/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
+++ b/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.examples.springboot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.Model;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstanceReadMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = DemoApplication.class)
+public class ProcessMetricsTest {
+
+    private static final String PROJECT_VERSION = ProjectMetadataProvider.getProjectVersion();
+    private static final String PROJECT_ARTIFACT_ID = ProjectMetadataProvider.getProjectArtifactId();
+
+    // restassured needs to know the random port created for test
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    @Qualifier("demo.orders")
+    Process<? extends Model> orderProcess;
+
+    @Autowired
+    @Qualifier("demo.orderItems")
+    Process<? extends Model> orderItemsProcess;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+
+        // need it when running with persistence
+        orderProcess.instances().values(ProcessInstanceReadMode.MUTABLE).forEach(pi -> pi.abort());
+        orderItemsProcess.instances().values(ProcessInstanceReadMode.MUTABLE).forEach(pi -> pi.abort());
+    }
+
+    @Test
+    public void testProcessMetricsSpringboot() {
+        assertNotNull(orderProcess);
+
+        // test adding new order
+        String addOrderPayload = "{\"approver\" : \"john\", \"order\" : {\"orderNumber\" : \"12345\", \"shipped\" : false}}";
+        String firstCreatedId = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(addOrderPayload).when()
+                .post("/orders")
+                .then()
+                .statusCode(201)
+                .header("Location", notNullValue())
+                .extract().path("id");
+
+        // test getting the created order
+        given().accept(ContentType.JSON).when().get("/orders").then().statusCode(200)
+                .body("$.size()", is(1), "[0].id", is(firstCreatedId));
+
+        given()
+                .when()
+                .get("/metrics")
+                .then()
+                .statusCode(200)
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orders\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_started_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orderItems\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orders\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"demo.orderItems\",version=\"%s\",} 1.0",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format(
+                                "kogito_work_item_duration_seconds_max{artifactId=\"%s\",name=\"org.kie.kogito.examples.springboot.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format(
+                                "kogito_work_item_duration_seconds_count{artifactId=\"%s\",name=\"org.kie.kogito.examples.springboot.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)))
+                .body(containsString(
+                        String.format(
+                                "kogito_work_item_duration_seconds_sum{artifactId=\"%s\",name=\"org.kie.kogito.examples.springboot.CalculationService_calculateTotal_3_Handler\",version=\"%s\",}",
+                                PROJECT_ARTIFACT_ID, PROJECT_VERSION)));
+    }
+}

--- a/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProjectMetadataProvider.java
+++ b/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProjectMetadataProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples.springboot;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class ProjectMetadataProvider {
+
+    private static final Properties props = new Properties();
+
+    private static final String projectVersion;
+    private static final String projectArtifactId;
+
+    static {
+        String propertyFileName = "project.properties";
+        try {
+            props.load(ProjectMetadataProvider.class.getClassLoader().getResourceAsStream(propertyFileName));
+            projectVersion = props.getProperty("project.version");
+            projectArtifactId = props.getProperty("project.artifactId");
+        } catch (IOException e) {
+            throw new IllegalStateException("Impossible to retrieve property file " + propertyFileName, e);
+        }
+        if (projectVersion == null || projectArtifactId == null || projectVersion.startsWith("${") || projectArtifactId.startsWith("${")) {
+            throw new IllegalStateException("The projectVersion and/or the projectArtifactId maven properties are not configured properly.");
+        }
+    }
+
+    public static String getProjectVersion() {
+        return projectVersion;
+    }
+
+    public static String getProjectArtifactId() {
+        return projectArtifactId;
+    }
+}


### PR DESCRIPTION
The goal of this PR is to extend test coverage for "process-monitoring-quarkus" to check metrics the same way as "dmn-drools-quarkus-metrics" and to extend "process-monitoring-springboot" to check metrics the same way as "dmn-drools-springboot-metrics".