### PR TITLE
KOGITO-5280 Create a profile for optaplanner dowstream build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,36 @@
         <module>serverless-workflow-service-calls-springboot</module>
       </modules>
     </profile>
+    <profile>
+      <id>optaplanner-downstream</id>
+      <activation>
+        <property>
+          <name>optaplanner</name>
+        </property>
+      </activation>
+      <modules>
+        <module>process-optaplanner-quarkus</module>
+        <module>process-optaplanner-springboot</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>optaplanner-downstream-native</id>
+      <activation>
+        <property>
+          <name>optaplanner-native</name>
+        </property>
+      </activation>
+      <properties>
+        <failsafe.include>**/Native*IT.java</failsafe.include>
+        <failsafe.exclude></failsafe.exclude>
+        <quarkus.package.type>native</quarkus.package.type>
+        <!-- Native building needs a fixed port for tests -->
+        <tests.quarkus.http.port>8080</tests.quarkus.http.port>
+      </properties>
+      <modules>
+        <module>process-optaplanner-quarkus</module>
+      </modules>
+    </profile>
   </profiles>
 
   <dependencyManagement>


### PR DESCRIPTION
The idea is to set up a profile that activates only modules relevant for the OptaPlanner downstream build.

Motivation: Make the downstream build faster and more stable by running only those modules that depend on OptaPlanner.
Alternative: To active the modules directly from the CI (but that makes the CI dependent on the internal structure of the project).

### JIRA
https://issues.redhat.com/browse/KOGITO-5280

### Referenced pull requests
https://github.com/kiegroup/kogito-apps/pull/1033

Please make sure that your PR meets the following requirements:

**WARNING! Please make sure you are opening your PR against `main` branch!**

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>