### PR TITLE
[KOGITO-6052] Protecting againts exception in abort

### DIFF
--- a/process-quarkus-example/src/test/java/org/kie/kogito/examples/PersonsRestIT.java
+++ b/process-quarkus-example/src/test/java/org/kie/kogito/examples/PersonsRestIT.java
@@ -49,7 +49,12 @@ public class PersonsRestIT {
     @BeforeEach
     public void cleanUp() {
         // need it when running with persistence
-        personProcess.instances().values().forEach(pi -> pi.abort());
+        try {
+            personProcess.instances().values().forEach(pi -> pi.abort());
+        } catch (IllegalArgumentException ex) {
+            // process might not longer be there is not persisted
+        }
+
     }
 
     @Test


### PR DESCRIPTION
Abort (which is added just for the persistence case) might throw an exception if the process is already removed (that's fine and can be ignored in the result of the test) 
Depends on https://github.com/kiegroup/kogito-runtimes/pull/1649