### PR TITLE
Adding serverless-workflow-error-quarkus to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
         <module>serverless-workflow-service-calls-quarkus</module>
         <module>serverless-workflow-service-calls-springboot</module>
         <module>serverless-workflow-events-quarkus</module>
+        <module>serverless-workflow-error-quarkus</module>
         <module>serverless-workflow-functions-quarkus</module>
         <module>serverless-workflow-functions-events-quarkus</module>
         <module>serverless-workflow-github-showcase</module>

--- a/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-error-quarkus/pom.xml
@@ -26,6 +26,14 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-serverless-workflow</artifactId>
     </dependency>
+     <dependency>
+       <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+     <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>


### PR DESCRIPTION
Just adding an example that should be there and was somehow missed in the general pom