### PR TITLE
[ISSUE 117] build-chain upgraded to v2.6.13

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,16 @@ Please make sure that your PR meets the following requirements:
 
 <details>
 <summary>
+How to replicate CI configuration locally?
+</summary>
+
+We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
+
+[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
+</details>
+
+<details>
+<summary>
 How to retest this PR or trigger a specific build:
 </summary>
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,9 +46,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.11
+        uses: kiegroup/github-action-build-chain@issues/117
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/kogito-pipelines/${BRANCH}/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
       - name: Publish Test Report
         if: ${{ always() }}
         uses: ScaCap/action-surefire-report@v1.0.10

--- a/decisiontable-quarkus-example/pom.xml
+++ b/decisiontable-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>

--- a/decisiontable-springboot-example/pom.xml
+++ b/decisiontable-springboot-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>

--- a/dmn-event-driven-quarkus/pom.xml
+++ b/dmn-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>

--- a/dmn-event-driven-springboot/pom.xml
+++ b/dmn-event-driven-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>

--- a/dmn-incubation-api-quarkus/pom.xml
+++ b/dmn-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>

--- a/dmn-knative-quickstart-quarkus/pom.xml
+++ b/dmn-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>

--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>

--- a/dmn-listener-springboot/pom.xml
+++ b/dmn-listener-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>

--- a/dmn-pmml-quarkus-example/pom.xml
+++ b/dmn-pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>

--- a/dmn-pmml-springboot-example/pom.xml
+++ b/dmn-pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>

--- a/dmn-quarkus-example/pom.xml
+++ b/dmn-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>

--- a/dmn-springboot-example/pom.xml
+++ b/dmn-springboot-example/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>

--- a/dmn-tracing-quarkus/pom.xml
+++ b/dmn-tracing-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>

--- a/dmn-tracing-springboot/pom.xml
+++ b/dmn-tracing-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>

--- a/flexible-process-quarkus/pom.xml
+++ b/flexible-process-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>

--- a/flexible-process-springboot/pom.xml
+++ b/flexible-process-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>

--- a/kogito-travel-agency/basic/pom.xml
+++ b/kogito-travel-agency/basic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>

--- a/kogito-travel-agency/extended/pom.xml
+++ b/kogito-travel-agency/extended/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-travel-agency/extended/travels/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>

--- a/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-travel-agency/extended/visas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>

--- a/kogito-travel-agency/pom.xml
+++ b/kogito-travel-agency/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/onboarding-example/hr/pom.xml
+++ b/onboarding-example/hr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/onboarding-example/onboarding-quarkus/pom.xml
+++ b/onboarding-example/onboarding-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/onboarding-example/onboarding-springboot/pom.xml
+++ b/onboarding-example/onboarding-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>onboarding-springboot</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Spring Boot</name>

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/onboarding-example/pom.xml
+++ b/onboarding-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>

--- a/pmml-event-driven-quarkus/pom.xml
+++ b/pmml-event-driven-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>

--- a/pmml-event-driven-springboot/pom.xml
+++ b/pmml-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>

--- a/pmml-incubation-api-quarkus/pom.xml
+++ b/pmml-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>

--- a/pmml-quarkus-example/pom.xml
+++ b/pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>

--- a/pmml-springboot-example/pom.xml
+++ b/pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -45,7 +45,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- kogito -->
     <kogito.version>${project.version}</kogito.version>
-    <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.12.0.Final</version.org.optaplanner>
     <!-- override default to fast-jar packaging for forward-compatibility -->
     <quarkus.package.type>fast-jar</quarkus.package.type>
     <!-- dependencies version -->

--- a/process-business-rules-quarkus/pom.xml
+++ b/process-business-rules-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>

--- a/process-business-rules-springboot/pom.xml
+++ b/process-business-rules-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>

--- a/process-decisions-quarkus/pom.xml
+++ b/process-decisions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>

--- a/process-decisions-rest-quarkus/pom.xml
+++ b/process-decisions-rest-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <properties>
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>

--- a/process-decisions-rest-springboot/pom.xml
+++ b/process-decisions-rest-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>

--- a/process-decisions-springboot/pom.xml
+++ b/process-decisions-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>

--- a/process-error-handling/pom.xml
+++ b/process-error-handling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-incubation-api-quarkus/pom.xml
+++ b/process-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>

--- a/process-infinispan-persistence-quarkus/pom.xml
+++ b/process-infinispan-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>

--- a/process-infinispan-persistence-springboot/pom.xml
+++ b/process-infinispan-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>

--- a/process-kafka-multi-quarkus/pom.xml
+++ b/process-kafka-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>

--- a/process-kafka-multi-springboot/pom.xml
+++ b/process-kafka-multi-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>

--- a/process-kafka-persistence-quarkus/pom.xml
+++ b/process-kafka-persistence-quarkus/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/process-kafka-quickstart-quarkus/pom.xml
+++ b/process-kafka-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>

--- a/process-kafka-quickstart-springboot/pom.xml
+++ b/process-kafka-quickstart-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>

--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>

--- a/process-mongodb-persistence-quarkus/pom.xml
+++ b/process-mongodb-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>

--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>

--- a/process-monitoring-quarkus/pom.xml
+++ b/process-monitoring-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>

--- a/process-monitoring-springboot/pom.xml
+++ b/process-monitoring-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>

--- a/process-optaplanner-quarkus/pom.xml
+++ b/process-optaplanner-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-optaplanner-quarkus</artifactId>
   <name>Kogito Example :: Process, OptaPlanner and Quarkus</name>

--- a/process-optaplanner-springboot/pom.xml
+++ b/process-optaplanner-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-optaplanner-springboot</artifactId>
 

--- a/process-outbox-mongodb-quarkus/pom.xml
+++ b/process-outbox-mongodb-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.12.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-quarkus</artifactId>

--- a/process-outbox-mongodb-springboot/pom.xml
+++ b/process-outbox-mongodb-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.12.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-springboot</artifactId>

--- a/process-postgresql-persistence-quarkus/pom.xml
+++ b/process-postgresql-persistence-quarkus/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>

--- a/process-postgresql-persistence-springboot/pom.xml
+++ b/process-postgresql-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>

--- a/process-quarkus-example/pom.xml
+++ b/process-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>

--- a/process-rest-service-call-quarkus/pom.xml
+++ b/process-rest-service-call-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>

--- a/process-rest-service-call-springboot/pom.xml
+++ b/process-rest-service-call-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>

--- a/process-rest-workitem-multi-quarkus/pom.xml
+++ b/process-rest-workitem-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>

--- a/process-rest-workitem-quarkus/pom.xml
+++ b/process-rest-workitem-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>

--- a/process-scripts-quarkus/pom.xml
+++ b/process-scripts-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-scripts-springboot/pom.xml
+++ b/process-scripts-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>

--- a/process-service-calls-quarkus/pom.xml
+++ b/process-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>

--- a/process-service-calls-springboot/pom.xml
+++ b/process-service-calls-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>

--- a/process-springboot-example/pom.xml
+++ b/process-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>

--- a/process-timer-springboot/pom.xml
+++ b/process-timer-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>

--- a/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>

--- a/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>

--- a/process-usertasks-quarkus-with-console/pom.xml
+++ b/process-usertasks-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-quarkus-with-console</artifactId>

--- a/process-usertasks-quarkus/pom.xml
+++ b/process-usertasks-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>

--- a/process-usertasks-springboot-with-console/pom.xml
+++ b/process-usertasks-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot-with-console</artifactId>

--- a/process-usertasks-springboot/pom.xml
+++ b/process-usertasks-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>

--- a/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>

--- a/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>

--- a/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>

--- a/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot-with-console</artifactId>

--- a/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>

--- a/process-usertasks-with-security-quarkus/pom.xml
+++ b/process-usertasks-with-security-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>

--- a/process-usertasks-with-security-springboot/pom.xml
+++ b/process-usertasks-with-security-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>

--- a/rules-incubation-api-quarkus/pom.xml
+++ b/rules-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>

--- a/rules-legacy-quarkus-example/pom.xml
+++ b/rules-legacy-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>

--- a/rules-legacy-springboot-example/pom.xml
+++ b/rules-legacy-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>

--- a/rules-quarkus-helloworld/pom.xml
+++ b/rules-quarkus-helloworld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>

--- a/ruleunit-event-driven-quarkus/pom.xml
+++ b/ruleunit-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>

--- a/ruleunit-event-driven-springboot/pom.xml
+++ b/ruleunit-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>

--- a/ruleunit-quarkus-example/pom.xml
+++ b/ruleunit-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>

--- a/ruleunit-springboot-example/pom.xml
+++ b/ruleunit-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>

--- a/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-functions-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-functions-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions And Events :: Quarkus</name>

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-functions-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>

--- a/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-funqy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.12.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy</name>

--- a/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.12.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy-services</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>

--- a/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.12.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy-workflow</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>github-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>notification-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>

--- a/serverless-workflow-github-showcase/pom.xml
+++ b/serverless-workflow-github-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-github-showcase</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>pr-checker-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>

--- a/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-greeting-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-greeting-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>

--- a/serverless-workflow-greeting-springboot/pom.xml
+++ b/serverless-workflow-greeting-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>serverless-workflow-greeting-springboot</artifactId>

--- a/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-order-processing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-examples</artifactId>
     <groupId>org.kie.kogito.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>

--- a/serverless-workflow-service-calls-springboot/pom.xml
+++ b/serverless-workflow-service-calls-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
 
   <artifactId>serverless-workflow-service-calls-springboot</artifactId>

--- a/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>

--- a/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>

--- a/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-temperature-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-temperature-conversion</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.12.0.Final</version>
   </parent>
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>

--- a/trusty-demonstration/docker-compose/docker-compose.yml
+++ b/trusty-demonstration/docker-compose/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - kafka
 
   explainability:
-    image: quay.io/kiegroup/kogito-explainability:1.5
+    image: quay.io/kiegroup/kogito-explainability:1.12
     depends_on:
       - kafka
       - kogito-app
@@ -66,7 +66,7 @@ services:
       - 1336:8080
 
   trusty:
-    image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+    image: quay.io/kiegroup/kogito-trusty-infinispan:1.12
     depends_on:
       - kafka
       - infinispan
@@ -79,7 +79,7 @@ services:
       - 1337:8080
 
   trusty-ui:
-    image: quay.io/kiegroup/kogito-trusty-ui:1.5
+    image: quay.io/kiegroup/kogito-trusty-ui:1.12
     depends_on:
       - kafka
     environment:

--- a/trusty-demonstration/kubernetes/README.md
+++ b/trusty-demonstration/kubernetes/README.md
@@ -57,7 +57,7 @@ kubectl create namespace "$PROJECT_NAME"
 Set the Kogito release version
 
 ```bash
-KOGITO_VERSION=v1.5.0
+KOGITO_VERSION=v1.12.0
 ```
 
 Deploy the kogito operator in the cluster
@@ -127,7 +127,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.4
+  image: quay.io/kiegroup/kogito-trusty-ui:1.12
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2:1337

--- a/trusty-demonstration/kubernetes/resources/explainability.yaml
+++ b/trusty-demonstration/kubernetes/resources/explainability.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   serviceType: Explainability
   replicas: 1
-  image: quay.io/kiegroup/kogito-explainability:1.5
+  image: quay.io/kiegroup/kogito-explainability:1.12
   infra:
     - kogito-kafka-infra

--- a/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
+++ b/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.5
+  image: quay.io/kiegroup/kogito-trusty-ui:1.12
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2

--- a/trusty-demonstration/kubernetes/resources/trusty.yaml
+++ b/trusty-demonstration/kubernetes/resources/trusty.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceType: TrustyAI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+  image: quay.io/kiegroup/kogito-trusty-infinispan:1.12
   infra:
     - kogito-kafka-infra
     - kogito-infinispan-infra


### PR DESCRIPTION
See build-chain update details at https://github.com/kiegroup/github-action-build-chain/pull/190

related PRs:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1798
- https://github.com/kiegroup/kie-soup/pull/235
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/576
- https://github.com/kiegroup/drools/pull/3959
- https://github.com/kiegroup/optaplanner/pull/1640
- https://github.com/kiegroup/lienzo-core/pull/156
- https://github.com/kiegroup/lienzo-tests/pull/130
- https://github.com/kiegroup/appformer/pull/1208
- https://github.com/kiegroup/kie-uberfire-extensions/pull/127
- https://github.com/kiegroup/jbpm/pull/2053
- https://github.com/kiegroup/kie-jpmml-integration/pull/69
- https://github.com/kiegroup/droolsjbpm-integration/pull/2638
- https://github.com/kiegroup/kie-wb-playground/pull/122
- https://github.com/kiegroup/kie-wb-common/pull/3699
- https://github.com/kiegroup/drools-wb/pull/1525
- https://github.com/kiegroup/jbpm-designer/pull/921
- https://github.com/kiegroup/jbpm-work-items/pull/222
- https://github.com/kiegroup/jbpm-wb/pull/1527
- https://github.com/kiegroup/optaplanner-wb/pull/408
- https://github.com/kiegroup/kie-wb-distributions/pull/1143
- https://github.com/kiegroup/openshift-drools-hacep/pull/121
- https://github.com/kiegroup/process-migration-service/pull/31
- https://github.com/kiegroup/optaweb-employee-rostering/pull/710
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/589
- https://github.com/kiegroup/kie-docs/pull/3981
- https://github.com/kiegroup/kogito-pipelines/pull/309
- https://github.com/kiegroup/kogito-runtimes/pull/1686
- https://github.com/kiegroup/kogito-apps/pull/1084
- https://github.com/kiegroup/kogito-examples/pull/961
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1150