### PR TITLE
[KOGITO-6306] Refining dmn-drools-*-metrics examples

### DIFF
--- a/dmn-drools-quarkus-metrics/README.md
+++ b/dmn-drools-quarkus-metrics/README.md
@@ -52,7 +52,7 @@ You can use these default dashboards, or you can personalize them and use your c
 ### Compile and Run in Local Dev Mode
 
 It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
-1. Run `mvn clean install` to build the project and generate dashboards. A docker image tagged `org.kie.kogito.examples/dmn-drools-quarkus-metrics-example:1.0` will be built (docker must be installed on your system).
+1. Run `mvn clean package` to build the project and generate dashboards. A docker image tagged `org.kie.kogito.examples/dmn-drools-quarkus-metrics-example:1.0` will be built (docker must be installed on your system).
 2. Run `docker-compose up` to start the applications. 
 
 The volumes of the grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are properly loaded at startup.

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -118,12 +118,13 @@
           </filesets>
         </configuration>
       </plugin>
+      <!-- Keep this after quarkus-maven-plugin, since both are bind to package phase, and this one has to be executed after !-->
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
             <id>copy-resources</id>
-            <phase>prepare-package</phase>
+            <phase>package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -143,7 +143,7 @@
           </execution>
           <execution>
             <id>copy-docker-compose-for-tests</id>
-            <phase>prepare-package</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
@@ -162,6 +162,7 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Keep this after maven-resources-plugin, since both copy-docker-compose-for-tests and this one are bind to pre-integration-test phase, and this one has to be executed after !-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/dmn-drools-springboot-metrics/README.md
+++ b/dmn-drools-springboot-metrics/README.md
@@ -52,7 +52,7 @@ You can use these default dashboards, or you can personalize them and use your c
 ### Compile and Run in Local Dev Mode
 
 It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
-1. Run `mvn clean install` to build the project and generate dashboards.  A docker image tagged `org.kie.kogito.examples/dmn-drools-springboot-metrics-example:1.0` will be built (docker must be installed on your system).
+1. Run `mvn clean package` to build the project and generate dashboards.  A docker image tagged `org.kie.kogito.examples/dmn-drools-springboot-metrics-example:1.0` will be built (docker must be installed on your system).
 2. Run `docker-compose up` to start the applications. 
 
 The volumes of the grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are properly loaded at startup.

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -109,12 +109,13 @@
           </filesets>
         </configuration>
       </plugin>
+      <!-- Keep this after kogito-maven-plugin, since both are bind to package phase, and this one has to be executed after !-->
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
             <id>copy-resources</id>
-            <phase>prepare-package</phase>
+            <phase>package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -134,7 +134,7 @@
           </execution>
           <execution>
             <id>copy-docker-compose-for-tests</id>
-            <phase>prepare-package</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
@@ -153,6 +153,7 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Keep this after maven-resources-plugin, since both copy-docker-compose-for-tests and this one are bind to pre-integration-test phase, and this one has to be executed after !-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
@danielezonca @jiripetrlik 

See https://issues.redhat.com/browse/KOGITO-6306

This pr
1) bind 
`maven-resources-plugin:copy-resource` to `package` phase, soon after compilation plugins, in both quarkus and spriungboot examples
2) update Readme.md, to indicate that it is possible to build and execute the example without installing generated artifact in local .m2