### PR TITLE
Apply #867 fix to 1.11.x branch to solve CI

### DIFF
--- a/process-postgresql-persistence-quarkus/src/main/resources/application.properties
+++ b/process-postgresql-persistence-quarkus/src/main/resources/application.properties
@@ -2,3 +2,5 @@ quarkus.swagger-ui.always-include=true
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=8g
+
+


### PR DESCRIPTION
Allegedly this was handled in:
https://github.com/kiegroup/kogito-examples/pull/867/files#diff-0449d84a4fa6275cac1bb71dde3d4e347ea57b9a93d7b77101f6c770943d8fbeR12-R13

but was not backported to 1.11.x

this should fix:

```
[2021-12-03T13:41:55.202Z] [INFO] --- quarkus-maven-plugin:2.2.3.Final:build (default) @ process-postgresql-persistence-quarkus ---
[2021-12-03T13:42:10.054Z] [INFO] [org.jboss.threads] JBoss Threads version 3.4.2.Final
[2021-12-03T13:42:10.054Z] [INFO] Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=false, usePrometheusMonitoring=false, useCloudEvents=false, useExplainability=false, useProcessSVG=false, useEventDrivenDecisions=false}
[2021-12-03T13:42:10.054Z] [INFO] Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=false, usePrometheusMonitoring=false, useCloudEvents=false, useExplainability=false, useProcessSVG=false, useEventDrivenDecisions=false}
[2021-12-03T13:42:10.054Z] [INFO] Generator discovery performed, found [openapispecs, processes, rules, decisions, predictions]
[2021-12-03T13:42:10.054Z] [INFO] Skipping generator 'openapispecs' because disabled
[2021-12-03T13:42:10.054Z] [INFO] Skipping generator 'decisions' because disabled
[2021-12-03T13:42:10.054Z] [INFO] Skipping generator 'predictions' because disabled
[2021-12-03T13:42:10.330Z] [WARNING] There's already a generated file named org/acme/deals/DealreviewsModel.java to be compiled. Ignoring.
[2021-12-03T13:42:10.330Z] [WARNING] There's already a generated file named org/acme/deals/DealsModel.java to be compiled. Ignoring.
[2021-12-03T13:42:11.706Z] [INFO] Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=false, usePrometheusMonitoring=false, useCloudEvents=false, useExplainability=false, useProcessSVG=false, useEventDrivenDecisions=false}
[2021-12-03T13:42:11.706Z] [INFO] No Java source to compile
[2021-12-03T13:42:12.661Z] [INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: /home/jenkins/workspace/KIE/kogito/1.11.x/nightly/kogito-examples-native/kogito-examples-it-events/process-postgresql-persistence-quarkus/target/process-postgresql-persistence-quarkus-native-image-source-jar/process-postgresql-persistence-quarkus-runner.jar
[2021-12-03T13:42:13.227Z] [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from /home/jenkins/workspace/KIE/kogito/1.11.x/nightly/kogito-examples-native/kogito-examples-it-events/process-postgresql-persistence-quarkus/target/process-postgresql-persistence-quarkus-native-image-source-jar/process-postgresql-persistence-quarkus-runner.jar
[2021-12-03T13:42:13.227Z] [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildContainerRunner] Using docker to run the native image builder
[2021-12-03T13:42:13.227Z] [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildContainerRunner] Checking image status quay.io/quarkus/ubi-quarkus-native-image:21.2-java11
[2021-12-03T13:42:13.485Z] 21.2-java11: Pulling from quarkus/ubi-quarkus-native-image
[2021-12-03T13:42:13.485Z] Digest: sha256:a5cd230149519fe1ec377857916a29bec4dac78f3a1d086151265ceba677ae6b
[2021-12-03T13:42:13.485Z] Status: Image is up to date for quay.io/quarkus/ubi-quarkus-native-image:21.2-java11
[2021-12-03T13:42:13.485Z] quay.io/quarkus/ubi-quarkus-native-image:21.2-java11
[2021-12-03T13:42:14.413Z] [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM 21.2.0 Java 11 CE (Java Version 11.0.12+6-jvmci-21.2-b08)
[2021-12-03T13:42:14.413Z] [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/jenkins/workspace/KIE/kogito/1.11.x/nightly/kogito-examples-native/kogito-examples-it-events/process-postgresql-persistence-quarkus/target/process-postgresql-persistence-quarkus-native-image-source-jar:/project:z --name build-native-YIBvz quay.io/quarkus/ubi-quarkus-native-image:21.2-java11 -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -J-Xmx8gkafka.bootstrap.servers=localhost:9092 -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -H:-ParseOnce -H:AdditionalSecurityProviders=com.sun.security.sasl.Provider,org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClientProvider,org.apache.kafka.common.security.scram.internals.ScramSaslClientProvider process-postgresql-persistence-quarkus-runner -jar process-postgresql-persistence-quarkus-runner.jar
[2021-12-03T13:42:14.977Z] Invalid maximum heap size: -Xmx8gkafka.bootstrap.servers=localhost:9092
[2021-12-03T13:42:14.977Z] Error: Could not create the Java Virtual Machine.
[2021-12-03T13:42:14.977Z] Error: A fatal exception has occurred. Program will exit.
[2021-12-03T13:42:14.977Z] Error: Image build request failed with exit status 1
[2021-12-03T13:42:15.233Z] [INFO]
```

notice:

```
Invalid maximum heap size: -Xmx8gkafka.bootstrap.servers=localhost:9092
```

which seems to be caused by:

https://github.com/kiegroup/kogito-examples/blob/3d212a435852d508c3dd8f50c09684c9fa8c24a9/process-postgresql-persistence-quarkus/pom.xml#L185-L187

and `application.properties` in `1.11.x` does not have newline before EOF, which could be causing this issue indeed only on this branch.

This should solve this thread of failure: https://kie.zulipchat.com/#narrow/stream/236603-kogito-ci/topic/.5B1.2E11.2Ex.5D.20Kogito.20Examples/near/263588521 (onwards)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>