### PR TITLE
Update Notification Bot to not clip the issue link

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Send a stream message
       uses: zulip/github-actions-zulip/send-message@e71e15b429b0e79cc7b63e4e3dad0146443fab6f
       env:
-        CONTENT: "I have detected a new issue on github:\n${{ github.event.issue.body }}\n-- This is an automatically relayed message. Don't reply to me directly, I'm just a bot and I don't understand human language (yet). You can reply using this link: \n${{ github.event.issue.html_url }}"
+        CONTENT: "I have detected a new issue on ${{ github.event.issue.html_url }}\nThis is an automatically relayed message. Don't reply to me directly.\n-- Issue description:\n${{ github.event.issue.body }}"
       with:
         api-key: ${{ secrets.ZULIP_BOT_SECRET }}
         email: 'github-kogito-bot@kie.zulipchat.com'

--- a/decisiontable-quarkus-example/pom.xml
+++ b/decisiontable-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>

--- a/decisiontable-quarkus-example/pom.xml
+++ b/decisiontable-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/decisiontable-quarkus-example/pom.xml
+++ b/decisiontable-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>

--- a/decisiontable-quarkus-example/pom.xml
+++ b/decisiontable-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/decisiontable-springboot-example/pom.xml
+++ b/decisiontable-springboot-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>

--- a/decisiontable-springboot-example/pom.xml
+++ b/decisiontable-springboot-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-drools-quarkus-metrics/pom.xml
+++ b/dmn-drools-quarkus-metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>

--- a/dmn-drools-springboot-metrics/pom.xml
+++ b/dmn-drools-springboot-metrics/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>

--- a/dmn-drools-springboot-metrics/src/test/resources/DockerfileTest
+++ b/dmn-drools-springboot-metrics/src/test/resources/DockerfileTest
@@ -1,5 +1,5 @@
-FROM adoptopenjdk/openjdk11:latest
-RUN mkdir -p /myapp
-ADD target/* /myapp/
-ENV port=8080
-CMD java -jar /myapp/dmn-drools-springboot-metrics.jar
+FROM fabric8/java-alpine-openjdk11-jre
+
+COPY target/dmn-drools-springboot-metrics.jar /deployments/
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/dmn-event-driven-quarkus/pom.xml
+++ b/dmn-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>

--- a/dmn-event-driven-quarkus/pom.xml
+++ b/dmn-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>

--- a/dmn-event-driven-quarkus/src/test/resources/application.properties
+++ b/dmn-event-driven-quarkus/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kafka.devservices.enabled=false

--- a/dmn-event-driven-springboot/pom.xml
+++ b/dmn-event-driven-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>

--- a/dmn-event-driven-springboot/pom.xml
+++ b/dmn-event-driven-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>

--- a/dmn-incubation-api-quarkus/pom.xml
+++ b/dmn-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-incubation-api-quarkus/pom.xml
+++ b/dmn-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>

--- a/dmn-incubation-api-quarkus/pom.xml
+++ b/dmn-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-incubation-api-quarkus/pom.xml
+++ b/dmn-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>

--- a/dmn-knative-quickstart-quarkus/pom.xml
+++ b/dmn-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>

--- a/dmn-knative-quickstart-quarkus/pom.xml
+++ b/dmn-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>

--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>

--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-listener-quarkus/pom.xml
+++ b/dmn-listener-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>

--- a/dmn-listener-springboot/pom.xml
+++ b/dmn-listener-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>

--- a/dmn-listener-springboot/pom.xml
+++ b/dmn-listener-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>

--- a/dmn-pmml-quarkus-example/pom.xml
+++ b/dmn-pmml-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-pmml-quarkus-example/pom.xml
+++ b/dmn-pmml-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-pmml-quarkus-example/pom.xml
+++ b/dmn-pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>

--- a/dmn-pmml-quarkus-example/pom.xml
+++ b/dmn-pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>

--- a/dmn-pmml-springboot-example/pom.xml
+++ b/dmn-pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>

--- a/dmn-pmml-springboot-example/pom.xml
+++ b/dmn-pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>

--- a/dmn-quarkus-example/pom.xml
+++ b/dmn-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-quarkus-example/pom.xml
+++ b/dmn-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>

--- a/dmn-quarkus-example/pom.xml
+++ b/dmn-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-quarkus-example/pom.xml
+++ b/dmn-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>

--- a/dmn-springboot-example/pom.xml
+++ b/dmn-springboot-example/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>

--- a/dmn-springboot-example/pom.xml
+++ b/dmn-springboot-example/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>

--- a/dmn-tracing-quarkus/pom.xml
+++ b/dmn-tracing-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>

--- a/dmn-tracing-quarkus/pom.xml
+++ b/dmn-tracing-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-tracing-quarkus/pom.xml
+++ b/dmn-tracing-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/dmn-tracing-quarkus/pom.xml
+++ b/dmn-tracing-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>

--- a/dmn-tracing-springboot/pom.xml
+++ b/dmn-tracing-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>

--- a/dmn-tracing-springboot/pom.xml
+++ b/dmn-tracing-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>

--- a/flexible-process-quarkus/pom.xml
+++ b/flexible-process-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>

--- a/flexible-process-quarkus/pom.xml
+++ b/flexible-process-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/flexible-process-quarkus/pom.xml
+++ b/flexible-process-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/flexible-process-quarkus/pom.xml
+++ b/flexible-process-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>

--- a/flexible-process-springboot/pom.xml
+++ b/flexible-process-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>

--- a/flexible-process-springboot/pom.xml
+++ b/flexible-process-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>

--- a/kogito-travel-agency/basic/pom.xml
+++ b/kogito-travel-agency/basic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>

--- a/kogito-travel-agency/basic/pom.xml
+++ b/kogito-travel-agency/basic/pom.xml
@@ -12,10 +12,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/kogito-travel-agency/basic/pom.xml
+++ b/kogito-travel-agency/basic/pom.xml
@@ -12,10 +12,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/kogito-travel-agency/basic/pom.xml
+++ b/kogito-travel-agency/basic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>

--- a/kogito-travel-agency/extended/pom.xml
+++ b/kogito-travel-agency/extended/pom.xml
@@ -15,10 +15,10 @@
     <module>visas</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/pom.xml
+++ b/kogito-travel-agency/extended/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-travel-agency/extended/pom.xml
+++ b/kogito-travel-agency/extended/pom.xml
@@ -15,10 +15,10 @@
     <module>visas</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/pom.xml
+++ b/kogito-travel-agency/extended/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-travel-agency/extended/travels/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>

--- a/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-travel-agency/extended/travels/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-travel-agency/extended/travels/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>

--- a/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-travel-agency/extended/travels/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-travel-agency/extended/visas/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-travel-agency/extended/visas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>

--- a/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-travel-agency/extended/visas/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-travel-agency/extended/visas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>

--- a/kogito-travel-agency/pom.xml
+++ b/kogito-travel-agency/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-travel-agency/pom.xml
+++ b/kogito-travel-agency/pom.xml
@@ -15,10 +15,10 @@
     <module>extended</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-travel-agency/pom.xml
+++ b/kogito-travel-agency/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-travel-agency/pom.xml
+++ b/kogito-travel-agency/pom.xml
@@ -15,10 +15,10 @@
     <module>extended</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/onboarding-example/hr/pom.xml
+++ b/onboarding-example/hr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/onboarding-example/hr/pom.xml
+++ b/onboarding-example/hr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/onboarding-example/onboarding-quarkus/pom.xml
+++ b/onboarding-example/onboarding-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/onboarding-example/onboarding-quarkus/pom.xml
+++ b/onboarding-example/onboarding-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/onboarding-example/onboarding-springboot/pom.xml
+++ b/onboarding-example/onboarding-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>onboarding-springboot</artifactId>

--- a/onboarding-example/onboarding-springboot/pom.xml
+++ b/onboarding-example/onboarding-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>onboarding-springboot</artifactId>

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>
   <description>Payroll related decisions for onboarding</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>
   <description>Payroll related decisions for onboarding</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/onboarding-example/payroll/pom.xml
+++ b/onboarding-example/payroll/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/onboarding-example/pom.xml
+++ b/onboarding-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>

--- a/onboarding-example/pom.xml
+++ b/onboarding-example/pom.xml
@@ -17,10 +17,10 @@
     <module>onboarding-quarkus</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/onboarding-example/pom.xml
+++ b/onboarding-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>

--- a/onboarding-example/pom.xml
+++ b/onboarding-example/pom.xml
@@ -17,10 +17,10 @@
     <module>onboarding-quarkus</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-event-driven-quarkus/pom.xml
+++ b/pmml-event-driven-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-event-driven-quarkus/pom.xml
+++ b/pmml-event-driven-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>

--- a/pmml-event-driven-quarkus/pom.xml
+++ b/pmml-event-driven-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>

--- a/pmml-event-driven-quarkus/pom.xml
+++ b/pmml-event-driven-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-event-driven-quarkus/src/test/resources/application.properties
+++ b/pmml-event-driven-quarkus/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kafka.devservices.enabled=false

--- a/pmml-event-driven-springboot/pom.xml
+++ b/pmml-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>

--- a/pmml-event-driven-springboot/pom.xml
+++ b/pmml-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>

--- a/pmml-incubation-api-quarkus/pom.xml
+++ b/pmml-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-incubation-api-quarkus/pom.xml
+++ b/pmml-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-incubation-api-quarkus/pom.xml
+++ b/pmml-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>

--- a/pmml-incubation-api-quarkus/pom.xml
+++ b/pmml-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>

--- a/pmml-quarkus-example/pom.xml
+++ b/pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>

--- a/pmml-quarkus-example/pom.xml
+++ b/pmml-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-quarkus-example/pom.xml
+++ b/pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>

--- a/pmml-quarkus-example/pom.xml
+++ b/pmml-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pmml-springboot-example/pom.xml
+++ b/pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>

--- a/pmml-springboot-example/pom.xml
+++ b/pmml-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -45,7 +45,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- kogito -->
     <kogito.version>${project.version}</kogito.version>
-    <version.org.optaplanner>8.14.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.14.0.Final</version.org.optaplanner>
     <!-- override default to fast-jar packaging for forward-compatibility -->
     <quarkus.package.type>fast-jar</quarkus.package.type>
     <!-- dependencies version -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
     <!-- JKube -->
     <version.org.eclipse.jkube>1.4.0</version.org.eclipse.jkube>
+    <version.docker.plugin>0.37.0</version.docker.plugin>
   </properties>
 
   <!-- distributionManagement section -->
@@ -705,6 +706,11 @@
           <groupId>org.eclipse.jkube</groupId>
           <artifactId>openshift-maven-plugin</artifactId>
           <version>${version.org.eclipse.jkube}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${version.docker.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/process-business-rules-quarkus/pom.xml
+++ b/process-business-rules-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>

--- a/process-business-rules-quarkus/pom.xml
+++ b/process-business-rules-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Business Rules Quarkus</name>
   <description>Kogito business rules invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-business-rules-quarkus/pom.xml
+++ b/process-business-rules-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Business Rules Quarkus</name>
   <description>Kogito business rules invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-business-rules-quarkus/pom.xml
+++ b/process-business-rules-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>

--- a/process-business-rules-springboot/pom.xml
+++ b/process-business-rules-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>

--- a/process-business-rules-springboot/pom.xml
+++ b/process-business-rules-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>

--- a/process-decisions-quarkus/pom.xml
+++ b/process-decisions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>

--- a/process-decisions-quarkus/pom.xml
+++ b/process-decisions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>

--- a/process-decisions-rest-quarkus/pom.xml
+++ b/process-decisions-rest-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <properties>
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>

--- a/process-decisions-rest-quarkus/pom.xml
+++ b/process-decisions-rest-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <properties>
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>

--- a/process-decisions-rest-springboot/pom.xml
+++ b/process-decisions-rest-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>

--- a/process-decisions-rest-springboot/pom.xml
+++ b/process-decisions-rest-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>

--- a/process-decisions-springboot/pom.xml
+++ b/process-decisions-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>

--- a/process-decisions-springboot/pom.xml
+++ b/process-decisions-springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>

--- a/process-error-handling/pom.xml
+++ b/process-error-handling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-error-handling/pom.xml
+++ b/process-error-handling/pom.xml
@@ -10,10 +10,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-error-handling/pom.xml
+++ b/process-error-handling/pom.xml
@@ -10,10 +10,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-error-handling/pom.xml
+++ b/process-error-handling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-incubation-api-quarkus/pom.xml
+++ b/process-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-incubation-api-quarkus/pom.xml
+++ b/process-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>

--- a/process-incubation-api-quarkus/pom.xml
+++ b/process-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-incubation-api-quarkus/pom.xml
+++ b/process-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>

--- a/process-infinispan-persistence-quarkus/pom.xml
+++ b/process-infinispan-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>

--- a/process-infinispan-persistence-quarkus/pom.xml
+++ b/process-infinispan-persistence-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
   <description>Process with Infinispan persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-infinispan-persistence-quarkus/pom.xml
+++ b/process-infinispan-persistence-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
   <description>Process with Infinispan persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-infinispan-persistence-quarkus/pom.xml
+++ b/process-infinispan-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>

--- a/process-infinispan-persistence-springboot/pom.xml
+++ b/process-infinispan-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>

--- a/process-infinispan-persistence-springboot/pom.xml
+++ b/process-infinispan-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>

--- a/process-kafka-multi-quarkus/pom.xml
+++ b/process-kafka-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>

--- a/process-kafka-multi-quarkus/pom.xml
+++ b/process-kafka-multi-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
   <description>Kogito with Kafka - Quarkus, using one channel per message name</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-multi-quarkus/pom.xml
+++ b/process-kafka-multi-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
   <description>Kogito with Kafka - Quarkus, using one channel per message name</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-multi-quarkus/pom.xml
+++ b/process-kafka-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>

--- a/process-kafka-multi-quarkus/src/test/resources/application.properties
+++ b/process-kafka-multi-quarkus/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kafka.devservices.enabled=false

--- a/process-kafka-multi-springboot/pom.xml
+++ b/process-kafka-multi-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>

--- a/process-kafka-multi-springboot/pom.xml
+++ b/process-kafka-multi-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>

--- a/process-kafka-persistence-quarkus/pom.xml
+++ b/process-kafka-persistence-quarkus/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/process-kafka-persistence-quarkus/pom.xml
+++ b/process-kafka-persistence-quarkus/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/process-kafka-persistence-quarkus/pom.xml
+++ b/process-kafka-persistence-quarkus/pom.xml
@@ -29,10 +29,10 @@
   <name>Kogito Example :: Process Kafka Persistence Quarkus</name>
   <description>Process with Kafka persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-persistence-quarkus/pom.xml
+++ b/process-kafka-persistence-quarkus/pom.xml
@@ -29,10 +29,10 @@
   <name>Kogito Example :: Process Kafka Persistence Quarkus</name>
   <description>Process with Kafka persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-quickstart-quarkus/pom.xml
+++ b/process-kafka-quickstart-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
   <description>Kogito with Kafka - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-quickstart-quarkus/pom.xml
+++ b/process-kafka-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>

--- a/process-kafka-quickstart-quarkus/pom.xml
+++ b/process-kafka-quickstart-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
   <description>Kogito with Kafka - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-kafka-quickstart-quarkus/pom.xml
+++ b/process-kafka-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>

--- a/process-kafka-quickstart-quarkus/src/test/resources/application.properties
+++ b/process-kafka-quickstart-quarkus/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 # Quarkus
 quarkus.http.test-port=0
+quarkus.kafka.devservices.enabled=false
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g

--- a/process-kafka-quickstart-springboot/pom.xml
+++ b/process-kafka-quickstart-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>

--- a/process-kafka-quickstart-springboot/pom.xml
+++ b/process-kafka-quickstart-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>

--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>

--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -12,10 +12,10 @@
   <description>Kogito with Knative Eventing - Quarkus</description>
   <properties>
     <version.com.github.tomakehurst.wiremock>2.27.1</version.com.github.tomakehurst.wiremock>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>

--- a/process-knative-quickstart-quarkus/pom.xml
+++ b/process-knative-quickstart-quarkus/pom.xml
@@ -12,10 +12,10 @@
   <description>Kogito with Knative Eventing - Quarkus</description>
   <properties>
     <version.com.github.tomakehurst.wiremock>2.27.1</version.com.github.tomakehurst.wiremock>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-mongodb-persistence-quarkus/pom.xml
+++ b/process-mongodb-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>

--- a/process-mongodb-persistence-quarkus/pom.xml
+++ b/process-mongodb-persistence-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
   <description>Process with MongoDB persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-mongodb-persistence-quarkus/pom.xml
+++ b/process-mongodb-persistence-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
   <description>Process with MongoDB persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-mongodb-persistence-quarkus/pom.xml
+++ b/process-mongodb-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>

--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>

--- a/process-mongodb-persistence-springboot/pom.xml
+++ b/process-mongodb-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>

--- a/process-monitoring-quarkus/pom.xml
+++ b/process-monitoring-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>

--- a/process-monitoring-quarkus/pom.xml
+++ b/process-monitoring-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>

--- a/process-monitoring-quarkus/pom.xml
+++ b/process-monitoring-quarkus/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
@@ -35,16 +35,16 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
-      <dependency>
-          <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-resteasy</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-resteasy-jackson</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
 
-      <dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>

--- a/process-monitoring-springboot/pom.xml
+++ b/process-monitoring-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>

--- a/process-monitoring-springboot/pom.xml
+++ b/process-monitoring-springboot/pom.xml
@@ -26,6 +26,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-processes-spring-boot-starter</artifactId>
     </dependency>

--- a/process-monitoring-springboot/pom.xml
+++ b/process-monitoring-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>

--- a/process-optaplanner-quarkus/pom.xml
+++ b/process-optaplanner-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-optaplanner-quarkus</artifactId>
   <name>Kogito Example :: Process, OptaPlanner and Quarkus</name>

--- a/process-optaplanner-quarkus/pom.xml
+++ b/process-optaplanner-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process, OptaPlanner and Quarkus</name>
   <description>Flight assignment process and optimization</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-optaplanner-quarkus/pom.xml
+++ b/process-optaplanner-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process, OptaPlanner and Quarkus</name>
   <description>Flight assignment process and optimization</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-optaplanner-quarkus/pom.xml
+++ b/process-optaplanner-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-optaplanner-quarkus</artifactId>
   <name>Kogito Example :: Process, OptaPlanner and Quarkus</name>

--- a/process-optaplanner-springboot/pom.xml
+++ b/process-optaplanner-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-optaplanner-springboot</artifactId>
 

--- a/process-optaplanner-springboot/pom.xml
+++ b/process-optaplanner-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-optaplanner-springboot</artifactId>
 

--- a/process-outbox-mongodb-quarkus/docker-compose.yml
+++ b/process-outbox-mongodb-quarkus/docker-compose.yml
@@ -14,18 +14,18 @@ services:
       - zookeeper
     environment:
       - ZOOKEEPER_CONNECT=zookeeper:2181
-  kafdrop:
-    image: obsidiandynamics/kafdrop
-    ports:
-      - ${KAFDROP_PORT}:9000
-    links:
-      - kafka
-    depends_on:
-      - kafka
-    environment:
-      KAFKA_BROKERCONNECT: "kafka:9092"
-      JVM_OPTS: "-Xms32M -Xmx64M"
-      SERVER_SERVLET_CONTEXTPATH: "/"
+#  kafdrop:
+#    image: obsidiandynamics/kafdrop
+#    ports:
+#      - ${KAFDROP_PORT}:9000
+#    links:
+#      - kafka
+#    depends_on:
+#      - kafka
+#    environment:
+#      KAFKA_BROKERCONNECT: "kafka:9092"
+#      JVM_OPTS: "-Xms32M -Xmx64M"
+#      SERVER_SERVLET_CONTEXTPATH: "/"
   mongodb:
     build: ./mongodb
     image: kogito/outbox/mongodb

--- a/process-outbox-mongodb-quarkus/mongodb/Dockerfile
+++ b/process-outbox-mongodb-quarkus/mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4
+FROM mongo:4.4.10
 
 COPY init.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/init.sh

--- a/process-outbox-mongodb-quarkus/pom.xml
+++ b/process-outbox-mongodb-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-quarkus</artifactId>

--- a/process-outbox-mongodb-quarkus/pom.xml
+++ b/process-outbox-mongodb-quarkus/pom.xml
@@ -14,10 +14,10 @@
     <description>Process with Transactional Outbox - MongoDB and Quarkus</description>
 
     <properties>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <docker.showLogs>true</docker.showLogs>
         <docker.removeVolumes>true</docker.removeVolumes>
         <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>

--- a/process-outbox-mongodb-quarkus/pom.xml
+++ b/process-outbox-mongodb-quarkus/pom.xml
@@ -14,10 +14,10 @@
     <description>Process with Transactional Outbox - MongoDB and Quarkus</description>
 
     <properties>
-        <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
         <docker.showLogs>true</docker.showLogs>
         <docker.removeVolumes>true</docker.removeVolumes>
         <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
@@ -134,6 +134,7 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <external>

--- a/process-outbox-mongodb-quarkus/pom.xml
+++ b/process-outbox-mongodb-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-quarkus</artifactId>

--- a/process-outbox-mongodb-quarkus/sidecar/Dockerfile
+++ b/process-outbox-mongodb-quarkus/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4
+FROM mongo:4.4.10
 
 RUN apt-get update && apt-get install -y curl
 

--- a/process-outbox-mongodb-springboot/docker-compose.yml
+++ b/process-outbox-mongodb-springboot/docker-compose.yml
@@ -14,18 +14,18 @@ services:
       - zookeeper
     environment:
       - ZOOKEEPER_CONNECT=zookeeper:2181
-  kafdrop:
-    image: obsidiandynamics/kafdrop
-    ports:
-      - ${KAFDROP_PORT}:9000
-    links:
-      - kafka
-    depends_on:
-      - kafka
-    environment:
-      KAFKA_BROKERCONNECT: "kafka:9092"
-      JVM_OPTS: "-Xms32M -Xmx64M"
-      SERVER_SERVLET_CONTEXTPATH: "/"
+#  kafdrop:
+#    image: obsidiandynamics/kafdrop
+#    ports:
+#      - ${KAFDROP_PORT}:9000
+#    links:
+#      - kafka
+#    depends_on:
+#      - kafka
+#    environment:
+#      KAFKA_BROKERCONNECT: "kafka:9092"
+#      JVM_OPTS: "-Xms32M -Xmx64M"
+#      SERVER_SERVLET_CONTEXTPATH: "/"
   mongodb:
     build: ./mongodb
     image: kogito/outbox/mongodb

--- a/process-outbox-mongodb-springboot/kogito/Dockerfile
+++ b/process-outbox-mongodb-springboot/kogito/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM fabric8/java-alpine-openjdk11-jre
 
 VOLUME /tmp
 

--- a/process-outbox-mongodb-springboot/mongodb/Dockerfile
+++ b/process-outbox-mongodb-springboot/mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4
+FROM mongo:4.4.10
 
 COPY init.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/init.sh

--- a/process-outbox-mongodb-springboot/pom.xml
+++ b/process-outbox-mongodb-springboot/pom.xml
@@ -173,6 +173,7 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <external>

--- a/process-outbox-mongodb-springboot/pom.xml
+++ b/process-outbox-mongodb-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-springboot</artifactId>

--- a/process-outbox-mongodb-springboot/pom.xml
+++ b/process-outbox-mongodb-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-springboot</artifactId>

--- a/process-outbox-mongodb-springboot/sidecar/Dockerfile
+++ b/process-outbox-mongodb-springboot/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4
+FROM mongo:4.4.10
 
 RUN apt-get update && apt-get install -y curl
 

--- a/process-performance-quarkus/pom.xml
+++ b/process-performance-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>

--- a/process-performance-quarkus/pom.xml
+++ b/process-performance-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>

--- a/process-performance-quarkus/src/main/resources/application.properties
+++ b/process-performance-quarkus/src/main/resources/application.properties
@@ -3,8 +3,6 @@
 
 kafka.bootstrap.servers=localhost:9092
 
-
-
 mp.messaging.outgoing.done.connector=smallrye-kafka
 mp.messaging.outgoing.done.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
@@ -15,8 +13,6 @@ mp.messaging.incoming.test2.connector=smallrye-kafka
 mp.messaging.incoming.test2.topic=test
 mp.messaging.incoming.test2.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
-
-
 smallrye.messaging.worker.kogito-event-worker.max-concurrency=10
 
 mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-kafka
@@ -26,7 +22,6 @@ mp.messaging.outgoing.kogito_outgoing_stream.value.serializer=org.apache.kafka.c
 mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-kafka
 mp.messaging.incoming.kogito_incoming_stream.topic=test
 mp.messaging.incoming.kogito_incoming_stream.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-
 
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=6g

--- a/process-performance-springboot/pom.xml
+++ b/process-performance-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>

--- a/process-performance-springboot/pom.xml
+++ b/process-performance-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>

--- a/process-postgresql-persistence-quarkus/pom.xml
+++ b/process-postgresql-persistence-quarkus/pom.xml
@@ -16,10 +16,10 @@
   <name>Kogito Example :: Process PostgreSQL Persistence Quarkus</name>
   <description>Process with PostgreSQL persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-postgresql-persistence-quarkus/pom.xml
+++ b/process-postgresql-persistence-quarkus/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>

--- a/process-postgresql-persistence-quarkus/pom.xml
+++ b/process-postgresql-persistence-quarkus/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>

--- a/process-postgresql-persistence-quarkus/pom.xml
+++ b/process-postgresql-persistence-quarkus/pom.xml
@@ -16,10 +16,10 @@
   <name>Kogito Example :: Process PostgreSQL Persistence Quarkus</name>
   <description>Process with PostgreSQL persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-postgresql-persistence-springboot/pom.xml
+++ b/process-postgresql-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>

--- a/process-postgresql-persistence-springboot/pom.xml
+++ b/process-postgresql-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>

--- a/process-quarkus-example/pom.xml
+++ b/process-quarkus-example/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process and Quarkus</name>
   <description>Order management service</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-quarkus-example/pom.xml
+++ b/process-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>

--- a/process-quarkus-example/pom.xml
+++ b/process-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>

--- a/process-quarkus-example/pom.xml
+++ b/process-quarkus-example/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process and Quarkus</name>
   <description>Order management service</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-service-call-quarkus/pom.xml
+++ b/process-rest-service-call-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>

--- a/process-rest-service-call-quarkus/pom.xml
+++ b/process-rest-service-call-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>

--- a/process-rest-service-call-quarkus/pom.xml
+++ b/process-rest-service-call-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
   <description>Kogito service invocation using REST - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-service-call-quarkus/pom.xml
+++ b/process-rest-service-call-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
   <description>Kogito service invocation using REST - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-service-call-springboot/pom.xml
+++ b/process-rest-service-call-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>

--- a/process-rest-service-call-springboot/pom.xml
+++ b/process-rest-service-call-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>

--- a/process-rest-workitem-multi-quarkus/pom.xml
+++ b/process-rest-workitem-multi-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Rest :: Quarkus</name>
   <description>Invoking multiple Rest WS using RestWorkItemHandler</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-workitem-multi-quarkus/pom.xml
+++ b/process-rest-workitem-multi-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Rest :: Quarkus</name>
   <description>Invoking multiple Rest WS using RestWorkItemHandler</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-workitem-multi-quarkus/pom.xml
+++ b/process-rest-workitem-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>

--- a/process-rest-workitem-multi-quarkus/pom.xml
+++ b/process-rest-workitem-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>

--- a/process-rest-workitem-quarkus/pom.xml
+++ b/process-rest-workitem-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>

--- a/process-rest-workitem-quarkus/pom.xml
+++ b/process-rest-workitem-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
   <description>Kogito service invocation using REST work item and Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-workitem-quarkus/pom.xml
+++ b/process-rest-workitem-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
   <description>Kogito service invocation using REST work item and Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-rest-workitem-quarkus/pom.xml
+++ b/process-rest-workitem-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>

--- a/process-scripts-quarkus/pom.xml
+++ b/process-scripts-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-scripts-quarkus/pom.xml
+++ b/process-scripts-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-scripts-quarkus/pom.xml
+++ b/process-scripts-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>

--- a/process-scripts-quarkus/pom.xml
+++ b/process-scripts-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-scripts-springboot/pom.xml
+++ b/process-scripts-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>

--- a/process-scripts-springboot/pom.xml
+++ b/process-scripts-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>

--- a/process-service-calls-quarkus/pom.xml
+++ b/process-service-calls-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
   <description>Kogito service invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-service-calls-quarkus/pom.xml
+++ b/process-service-calls-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
   <description>Kogito service invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-service-calls-quarkus/pom.xml
+++ b/process-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>

--- a/process-service-calls-quarkus/pom.xml
+++ b/process-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>

--- a/process-service-calls-springboot/pom.xml
+++ b/process-service-calls-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>

--- a/process-service-calls-springboot/pom.xml
+++ b/process-service-calls-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>

--- a/process-springboot-example/pom.xml
+++ b/process-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>

--- a/process-springboot-example/pom.xml
+++ b/process-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Timer with Quarkus</name>
   <description>Kogito with timers - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>

--- a/process-timer-quarkus/pom.xml
+++ b/process-timer-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Timer with Quarkus</name>
   <description>Kogito with timers - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-timer-springboot/pom.xml
+++ b/process-timer-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>

--- a/process-timer-springboot/pom.xml
+++ b/process-timer-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>

--- a/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
   <description>Kogito user tasks orchestration with custom life cycle - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
   <description>Kogito user tasks orchestration with custom life cycle - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>

--- a/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>

--- a/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>

--- a/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>

--- a/process-usertasks-quarkus-with-console/pom.xml
+++ b/process-usertasks-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-quarkus-with-console</artifactId>

--- a/process-usertasks-quarkus-with-console/pom.xml
+++ b/process-usertasks-quarkus-with-console/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-usertasks-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus :: Console </name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-quarkus-with-console/pom.xml
+++ b/process-usertasks-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-quarkus-with-console</artifactId>

--- a/process-usertasks-quarkus-with-console/pom.xml
+++ b/process-usertasks-quarkus-with-console/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-usertasks-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus :: Console </name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-quarkus/pom.xml
+++ b/process-usertasks-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
   <description>Kogito user tasks orchestration - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-quarkus/pom.xml
+++ b/process-usertasks-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
   <description>Kogito user tasks orchestration - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-quarkus/pom.xml
+++ b/process-usertasks-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>

--- a/process-usertasks-quarkus/pom.xml
+++ b/process-usertasks-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>

--- a/process-usertasks-springboot-with-console/pom.xml
+++ b/process-usertasks-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot-with-console</artifactId>

--- a/process-usertasks-springboot-with-console/pom.xml
+++ b/process-usertasks-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot-with-console</artifactId>

--- a/process-usertasks-springboot/pom.xml
+++ b/process-usertasks-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>

--- a/process-usertasks-springboot/pom.xml
+++ b/process-usertasks-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>

--- a/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>

--- a/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process UserTasks with Timer Quarkus :: Console</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process UserTasks with Timer Quarkus :: Console</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>

--- a/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - open id connect adapter(keycloak)</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>

--- a/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>

--- a/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - open id connect adapter(keycloak)</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>

--- a/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - open id connect adapter(keycloak)</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>

--- a/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - open id connect adapter(keycloak)</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot-with-console</artifactId>

--- a/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot-with-console</artifactId>

--- a/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>

--- a/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>

--- a/process-usertasks-with-security-quarkus/pom.xml
+++ b/process-usertasks-with-security-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-quarkus/pom.xml
+++ b/process-usertasks-with-security-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/process-usertasks-with-security-quarkus/pom.xml
+++ b/process-usertasks-with-security-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>

--- a/process-usertasks-with-security-quarkus/pom.xml
+++ b/process-usertasks-with-security-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>

--- a/process-usertasks-with-security-springboot/pom.xml
+++ b/process-usertasks-with-security-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>

--- a/process-usertasks-with-security-springboot/pom.xml
+++ b/process-usertasks-with-security-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>

--- a/rules-incubation-api-quarkus/pom.xml
+++ b/rules-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rules-incubation-api-quarkus/pom.xml
+++ b/rules-incubation-api-quarkus/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rules-incubation-api-quarkus/pom.xml
+++ b/rules-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>

--- a/rules-incubation-api-quarkus/pom.xml
+++ b/rules-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>

--- a/rules-legacy-quarkus-example/pom.xml
+++ b/rules-legacy-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>

--- a/rules-legacy-quarkus-example/pom.xml
+++ b/rules-legacy-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rules-legacy-quarkus-example/pom.xml
+++ b/rules-legacy-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>

--- a/rules-legacy-quarkus-example/pom.xml
+++ b/rules-legacy-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rules-legacy-springboot-example/pom.xml
+++ b/rules-legacy-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>

--- a/rules-legacy-springboot-example/pom.xml
+++ b/rules-legacy-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>

--- a/rules-quarkus-helloworld/pom.xml
+++ b/rules-quarkus-helloworld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>

--- a/rules-quarkus-helloworld/pom.xml
+++ b/rules-quarkus-helloworld/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rules-quarkus-helloworld/pom.xml
+++ b/rules-quarkus-helloworld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>

--- a/rules-quarkus-helloworld/pom.xml
+++ b/rules-quarkus-helloworld/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/ruleunit-event-driven-quarkus/pom.xml
+++ b/ruleunit-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>

--- a/ruleunit-event-driven-quarkus/pom.xml
+++ b/ruleunit-event-driven-quarkus/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/ruleunit-event-driven-quarkus/pom.xml
+++ b/ruleunit-event-driven-quarkus/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/ruleunit-event-driven-quarkus/pom.xml
+++ b/ruleunit-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>

--- a/ruleunit-event-driven-quarkus/src/test/resources/application.properties
+++ b/ruleunit-event-driven-quarkus/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kafka.devservices.enabled=false

--- a/ruleunit-event-driven-springboot/pom.xml
+++ b/ruleunit-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>

--- a/ruleunit-event-driven-springboot/pom.xml
+++ b/ruleunit-event-driven-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>

--- a/ruleunit-quarkus-example/pom.xml
+++ b/ruleunit-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>

--- a/ruleunit-quarkus-example/pom.xml
+++ b/ruleunit-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/ruleunit-quarkus-example/pom.xml
+++ b/ruleunit-quarkus-example/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/ruleunit-quarkus-example/pom.xml
+++ b/ruleunit-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>

--- a/ruleunit-springboot-example/pom.xml
+++ b/ruleunit-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>

--- a/ruleunit-springboot-example/pom.xml
+++ b/ruleunit-springboot-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>

--- a/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-callback-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-callback-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Callback :: Quarkus</name>

--- a/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-callback-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-callback-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Callback :: Quarkus</name>

--- a/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-error-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-error-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Error :: Quarkus</name>

--- a/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-error-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-error-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Error :: Quarkus</name>

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>

--- a/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Events :: Quarkus</name>

--- a/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-expression-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-expression-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Expression :: Quarkus</name>

--- a/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-expression-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-expression-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Expression :: Quarkus</name>

--- a/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-functions-events-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Functions And Events :: Quarkus</name>
   <description>Kogito Serverless Workflow Functions And Events Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-functions-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-functions-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions And Events :: Quarkus</name>

--- a/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-functions-events-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-functions-events-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions And Events :: Quarkus</name>

--- a/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-functions-events-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Functions And Events :: Quarkus</name>
   <description>Kogito Serverless Workflow Functions And Events Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-functions-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-functions-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>

--- a/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-functions-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Functions :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-funqy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy</name>

--- a/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-funqy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>serverless-workflow-funqy</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy</name>

--- a/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>serverless-workflow-funqy-services</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>

--- a/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy-services</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>

--- a/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -11,10 +11,10 @@
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>
     <description>Kogito Serverless Workflow Funqy Services - Quarkus</description>
     <properties>
-      <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+      <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-      <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+      <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/serverless-workflow-funqy/sw-funqy-services/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-services/pom.xml
@@ -11,10 +11,10 @@
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Services</name>
     <description>Kogito Serverless Workflow Funqy Services - Quarkus</description>
     <properties>
-      <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+      <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-      <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+      <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>serverless-workflow-funqy-workflow</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>

--- a/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -11,10 +11,10 @@
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>
     <description>Kogito Serverless Workflow Funqy Workflow - Quarkus</description>
     <properties>
-      <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+      <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-      <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+      <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -11,10 +11,10 @@
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>
     <description>Kogito Serverless Workflow Funqy Workflow - Quarkus</description>
     <properties>
-      <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+      <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-      <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+      <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
     </properties>
     <dependencyManagement>
       <dependencies>

--- a/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>serverless-workflow-funqy</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0.Final</version>
     </parent>
     <artifactId>serverless-workflow-funqy-workflow</artifactId>
     <name>Kogito Example :: Serverless Workflow :: Funqy :: Workflow</name>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>github-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-<quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+<quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>github-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-<quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+<quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>github-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>

--- a/serverless-workflow-github-showcase/github-service/pom.xml
+++ b/serverless-workflow-github-showcase/github-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>github-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: GitHub Service</name>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>notification-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>notification-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>notification-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>

--- a/serverless-workflow-github-showcase/notification-service/pom.xml
+++ b/serverless-workflow-github-showcase/notification-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>notification-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: Notification Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-github-showcase/pom.xml
+++ b/serverless-workflow-github-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-github-showcase</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-github-showcase/pom.xml
+++ b/serverless-workflow-github-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-github-showcase</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>pr-checker-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pr-checker-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-github-showcase</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>pr-checker-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>

--- a/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
+++ b/serverless-workflow-github-showcase/pr-checker-workflow/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>pr-checker-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Github Showcase :: PR Checker Workflow</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
 
     <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
   </properties>

--- a/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-greeting-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-greeting-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-greeting-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>

--- a/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-greeting-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-greeting-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-greeting-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Greeting :: Quarkus</name>

--- a/serverless-workflow-greeting-springboot/pom.xml
+++ b/serverless-workflow-greeting-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>serverless-workflow-greeting-springboot</artifactId>

--- a/serverless-workflow-greeting-springboot/pom.xml
+++ b/serverless-workflow-greeting-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>serverless-workflow-greeting-springboot</artifactId>

--- a/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-order-processing/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>serverless-workflow-order-processing</artifactId>
   <name>Kogito Example :: Serverless Workflow Order Processing</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-order-processing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-examples</artifactId>
     <groupId>org.kie.kogito.examples</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-order-processing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-examples</artifactId>
     <groupId>org.kie.kogito.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-order-processing/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>serverless-workflow-order-processing</artifactId>
   <name>Kogito Example :: Serverless Workflow Order Processing</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-service-calls-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>

--- a/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-service-calls-quarkus/pom.xml
@@ -11,10 +11,10 @@
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>
   <description>Kogito Serverless Workflow Example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Serverless Workflow Service Calls :: Quarkus</name>

--- a/serverless-workflow-service-calls-springboot/pom.xml
+++ b/serverless-workflow-service-calls-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
 
   <artifactId>serverless-workflow-service-calls-springboot</artifactId>

--- a/serverless-workflow-service-calls-springboot/pom.xml
+++ b/serverless-workflow-service-calls-springboot/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>serverless-workflow-service-calls-springboot</artifactId>

--- a/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>

--- a/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>conversion-workflow</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Conversion Service</name>

--- a/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>

--- a/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>

--- a/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/multiplication-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>multiplication-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Multiplication Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-temperature-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>serverless-workflow-temperature-conversion</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-temperature-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>serverless-workflow-temperature-conversion</artifactId>
   <packaging>pom</packaging>

--- a/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>1.14.0.Final</version>
   </parent>
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>

--- a/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -10,10 +10,10 @@
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>
   <properties>
-    <quarkus-plugin.version>2.4.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
+++ b/serverless-workflow-temperature-conversion/subtraction-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-temperature-conversion</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>subtraction-service</artifactId>
   <name>Kogito Example :: Serverless Workflow Temperature Conversion :: Subtraction Service</name>

--- a/trusty-demonstration/docker-compose/docker-compose.yml
+++ b/trusty-demonstration/docker-compose/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - kafka
 
   explainability:
-    image: quay.io/kiegroup/kogito-explainability:1.5
+    image: quay.io/kiegroup/kogito-explainability:1.14
     depends_on:
       - kafka
       - kogito-app
@@ -66,7 +66,7 @@ services:
       - 1336:8080
 
   trusty:
-    image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+    image: quay.io/kiegroup/kogito-trusty-infinispan:1.14
     depends_on:
       - kafka
       - infinispan
@@ -79,7 +79,7 @@ services:
       - 1337:8080
 
   trusty-ui:
-    image: quay.io/kiegroup/kogito-trusty-ui:1.5
+    image: quay.io/kiegroup/kogito-trusty-ui:1.14
     depends_on:
       - kafka
     environment:

--- a/trusty-demonstration/kubernetes/README.md
+++ b/trusty-demonstration/kubernetes/README.md
@@ -57,7 +57,7 @@ kubectl create namespace "$PROJECT_NAME"
 Set the Kogito release version
 
 ```bash
-KOGITO_VERSION=v1.5.0
+KOGITO_VERSION=v1.14.0
 ```
 
 Deploy the kogito operator in the cluster
@@ -127,7 +127,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.4
+  image: quay.io/kiegroup/kogito-trusty-ui:1.14
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2:1337

--- a/trusty-demonstration/kubernetes/resources/explainability.yaml
+++ b/trusty-demonstration/kubernetes/resources/explainability.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   serviceType: Explainability
   replicas: 1
-  image: quay.io/kiegroup/kogito-explainability:1.5
+  image: quay.io/kiegroup/kogito-explainability:1.14
   infra:
     - kogito-kafka-infra

--- a/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
+++ b/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.5
+  image: quay.io/kiegroup/kogito-trusty-ui:1.14
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2

--- a/trusty-demonstration/kubernetes/resources/trusty.yaml
+++ b/trusty-demonstration/kubernetes/resources/trusty.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceType: TrustyAI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+  image: quay.io/kiegroup/kogito-trusty-infinispan:1.14
   infra:
     - kogito-kafka-infra
     - kogito-infinispan-infra


### PR DESCRIPTION
A Small change in the bot to not clip the issue link when the issue description is too large.

@danielezonca @tarilabs as soon as you approve, I'll replicate the changes to the other repos.