### PR TITLE
KOGITO-6507 Removed KafkaTestClient usage in compile scope from sw-callback-quarkus

### DIFF
--- a/kogito-quarkus-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/kogito-quarkus-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -34,10 +34,6 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-quarkus-test-utils</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-messaging</artifactId>
     </dependency>
     <dependency>
@@ -65,6 +61,11 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
@@ -7,7 +7,6 @@ mp.messaging.outgoing.outgoing-move.connector=smallrye-kafka
 mp.messaging.outgoing.outgoing-move.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.outgoing.outgoing-move.topic=move
 
-
 kogito.persistence.type=jdbc
 #run create tables scripts
 kogito.persistence.auto.ddl=true

--- a/kogito-quarkus-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
@@ -3,6 +3,11 @@ kafka.bootstrap.servers=localhost:9092
 mp.messaging.incoming.move.connector=smallrye-kafka
 mp.messaging.incoming.move.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
+mp.messaging.outgoing.outgoing-move.connector=smallrye-kafka
+mp.messaging.outgoing.outgoing-move.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.outgoing.outgoing-move.topic=move
+
+
 kogito.persistence.type=jdbc
 #run create tables scripts
 kogito.persistence.auto.ddl=true


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-6510

org.kie.kogito.test.quarkus.kafka.KafkaTestClient should be used only in test scope, but serverless-workflow-callback-quarkus was using it in compile scope. MicroProfile Reactive Messaging should be used rather than KafkaTestClient.