### PR TITLE
[1.16.x] KOGITO-5531 Update Jenkins CI to 3.8.1

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -12,7 +12,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -12,7 +12,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
     options {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -12,7 +12,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
@@ -76,7 +76,7 @@ docker-compose up
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.6.3+ installed
+  - Maven 3.8.1+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 20.2+ installed

--- a/kogito-quarkus-examples/serverless-workflow-github-showcase/README.md
+++ b/kogito-quarkus-examples/serverless-workflow-github-showcase/README.md
@@ -45,7 +45,7 @@ In your local machine you will need:
 
 1. To clone this repository and go to `serverless-workflow-github-showcase` directory (`git clone https://github.com/kiegroup/kogito-examples.git && cd serverless-workflow-github-showcase`)
 2. [Java 11 SDK](https://openjdk.java.net/install/)
-3. [Maven 3.6.3+](https://maven.apache.org/install.html)
+3. [Maven 3.8.1+](https://maven.apache.org/install.html)
 4. [Podman](https://podman.io/getting-started/installation.html) or Docker to build the images
 5. `kubectl` or `oc` client
 

--- a/trusty-demonstration/docker-compose/README.md
+++ b/trusty-demonstration/docker-compose/README.md
@@ -9,7 +9,7 @@ The `main` branch is aligned to the latest changes in all the repositories. This
 
 - docker version > 19.03.12
 - java version > 11
-- maven version > 3.6.3
+- maven version > 3.8.1
 - docker-compose version > 1.25.2
 
 Note: also previous versions of `docker` and `docker-compose` might work, but they were not tested. 

--- a/trusty-demonstration/kubernetes/README.md
+++ b/trusty-demonstration/kubernetes/README.md
@@ -10,7 +10,7 @@ The `main` branch is aligned to the latest changes in all the repositories. This
 - docker version > 19.03.12
 - minikube version  > 1.16.0
 - java version > 11
-- maven version > 3.6.3
+- maven version > 3.8.1
 - kubernetes version > 1.20
 
 Note: also previous versions of `docker`, `minikube` and `kubernetes`  might work, but they were not tested. 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5531

This is to harmonize all Jenkins CIs.
PR checks are already using the Maven 3.8.x

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/375
- https://github.com/kiegroup/drools/pull/4169
- https://github.com/kiegroup/kogito-runtimes/pull/1954
- https://github.com/kiegroup/optaplanner/pull/1814
- https://github.com/kiegroup/kogito-apps/pull/1220
- https://github.com/kiegroup/kogito-examples/pull/1105