### PR TITLE
Fix typo about dependency handling in dmn-event-driven-quarkus

### DIFF
--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
@@ -35,7 +35,7 @@ Like the other Kogito AddOns, the only required step to enable it is to include 
 </dependency>
 ```
 
-The version is implicitly derived from the `kogito-quarkus-bom` included in the `dependencyManagement` section.
+The version is implicitly derived from the BOM imported in the `dependencyManagement` section.
 
 ### Configuration
 


### PR DESCRIPTION
Just a small fix to have it consistent with older branches. I found the discrepancy when doing BOM consolidation on 1.13.x

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>