### PR TITLE
KOGITO-6988 GreetRestIT add missing test cases

### DIFF
--- a/kogito-quarkus-examples/serverless-workflow-greeting-quarkus/src/test/java/org/kie/kogito/examples/GreetRestIT.java
+++ b/kogito-quarkus-examples/serverless-workflow-greeting-quarkus/src/test/java/org/kie/kogito/examples/GreetRestIT.java
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 class GreetRestIT {
 
     @Test
-    void testGreetRest() {
+    void testEnglish() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
@@ -36,7 +36,10 @@ class GreetRestIT {
                 .then()
                 .statusCode(201)
                 .body("workflowdata.greeting", containsString("Hello"));
+    }
 
+    @Test
+    void testSpanish() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
@@ -45,5 +48,29 @@ class GreetRestIT {
                 .then()
                 .statusCode(201)
                 .body("workflowdata.greeting", containsString("Saludos"));
+    }
+
+    @Test
+    void testDefaultLanguage() {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body("{\"workflowdata\" : {\"name\" : \"John\"}}").when()
+                .post("/jsongreet")
+                .then()
+                .statusCode(201)
+                .body("workflowdata.greeting", containsString("Hello"));
+    }
+
+    @Test
+    void testUnsupportedLanguage() {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body("{\"workflowdata\" : {\"name\" : \"Jan\", \"language\":\"Czech\"}}").when()
+                .post("/jsongreet")
+                .then()
+                .statusCode(201)
+                .body("workflowdata.greeting", containsString("Hello"));
     }
 }


### PR DESCRIPTION
Adding default and non-supported language options to the GreetRestIT test.
Separeted existing test for English and Spanish into separate test methods.

https://issues.redhat.com/browse/KOGITO-6988



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>