### PR TITLE
[KOGITO-7046] Changing property to work with OpenAPI generator

### DIFF
--- a/kogito-quarkus-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/handle-frontend.sw.json
+++ b/kogito-quarkus-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/handle-frontend.sw.json
@@ -7,19 +7,13 @@
   "functions": [
     {
       "name": "AddLabels",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GitHubService",
-        "operation": "addLabels",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.examples.sw.github.workflow.GitHubService::addLabels"
     },
     {
       "name": "AddReviewers",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GitHubService",
-        "operation": "addReviewers",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.examples.sw.github.workflow.GitHubService::addReviewers"
     }
   ],
   "events": [

--- a/kogito-quarkus-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/pr-checker.sw.json
+++ b/kogito-quarkus-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/pr-checker.sw.json
@@ -7,11 +7,8 @@
   "functions": [
     {
       "name": "FetchPRFiles",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GitHubService",
-        "operation": "fetchPRFiles",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:java:org.kogito.examples.sw.github.workflow.GitHubService::fetchPRFiles"
     }
   ],
   "events": [

--- a/kogito-quarkus-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.log.category."org.acme".level=DEBUG
 # OpenApi client properties to access the query-service
-org.kogito.openapi.client.queryservice.base_path=${QUERYSERVICE_URL:http://localhost:8283}
+quarkus.rest-client."org.openapi.quarkus.api.DefaultApi".url=${QUERYSERVICE_URL:http://localhost:8283}
 quarkus.swagger-ui.always-include=true

--- a/kogito-quarkus-examples/serverless-workflow-saga-quarkus/src/main/resources/order-saga-error-handling.sw.json
+++ b/kogito-quarkus-examples/serverless-workflow-saga-quarkus/src/main/resources/order-saga-error-handling.sw.json
@@ -22,73 +22,48 @@
   "functions": [
     {
       "name": "reserveStock",
-      "metadata": {
-        "interface": "org.kie.kogito.StockService",
-        "operation": "reserveStock",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.StockService::reserveStock"
     },
     {
       "name": "cancelStock",
-      "metadata": {
-        "interface": "org.kie.kogito.StockService",
-        "operation": "cancelStock",
-        "type": "service"
-      }
+       "type": "custom",
+      "operation": "service:org.kie.kogito.StockService::cancelStock"
     },
     {
       "name": "processPayment",
-      "metadata": {
-        "interface": "org.kie.kogito.PaymentService",
-        "operation": "processPayment",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.PaymentService::processPayment"
     },
     {
       "name": "cancelPayment",
-      "metadata": {
-        "interface": "org.kie.kogito.PaymentService",
-        "operation": "cancelPayment",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.PaymentService::cancelPayment"
     },
     {
       "name": "scheduleShipping",
-      "metadata": {
-        "interface": "org.kie.kogito.ShippingService",
-        "operation": "scheduleShipping",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.ShippingService::scheduleShipping"
     },
     {
       "name": "cancelShipping",
-      "metadata": {
-        "interface": "org.kie.kogito.ShippingService",
-        "operation": "cancelShipping",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.ShippingService::cancelShipping"
     },
     {
       "name": "orderSuccess",
-      "metadata": {
-        "interface": "org.kie.kogito.OrderService",
-        "operation": "success",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.OrderService::success"
     },
     {
       "name": "orderFailure",
-      "metadata": {
-        "interface": "org.kie.kogito.OrderService",
-        "operation": "failure",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.OrderService::failure"
     },
     {
       "name": "log",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/kogito-quarkus-examples/serverless-workflow-service-calls-quarkus/src/main/resources/countryservice.sw.json
+++ b/kogito-quarkus-examples/serverless-workflow-service-calls-quarkus/src/main/resources/countryservice.sw.json
@@ -12,19 +12,13 @@
     },
     {
       "name": "classifySmallMediumFunction",
-      "metadata": {
-        "interface": "org.kogito.serverless.examples.CountriesClassifierResource",
-        "operation": "classifySmallMedium",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.serverless.examples.CountriesClassifierResource::classifySmallMedium"
     },
     {
       "name": "classifyLargeFunction",
-      "metadata": {
-        "interface": "org.kogito.serverless.examples.CountriesClassifierResource",
-        "operation": "classifyLarge",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.serverless.examples.CountriesClassifierResource::classifyLarge"
     }
   ],
   "states": [


### PR DESCRIPTION
This change the url property in the only example that is using openapi quarkiverse right now (we are breaking property backward compatibility with this one)

The reason this is the only one generating  is because it has this secton in its  pom 
```
<plugin>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>quarkus-maven-plugin</artifactId>
        <version>${quarkus-plugin.version}</version>
        <extensions>true</extensions>
        <executions>
          <execution>
            <goals>
              <goal>build</goal>
              <goal>generate-code</goal>
              <goal>generate-code-tests</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
```
while others have
 ```
<plugins>
      <plugin>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>quarkus-maven-plugin</artifactId>
        <version>${quarkus-plugin.version}</version>
        <executions>
          <execution>
            <goals>
              <goal>build</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
    </plugins>

```
We will use a follow up JIRA to update all examples. 
Depends on https://github.com/kiegroup/kogito-runtimes/pull/2179