### PR TITLE
[1.13.x-blue] KOGITO-7356 Do not use master node in pipelines (#1285)

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -8,7 +8,7 @@ deployProperties = [:]
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem16g'
+        label 'kie-rhel7 && kie-mem16g && !master'
     }
 
     tools {

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -8,7 +8,7 @@ kogitoExamplesRepo = 'kogito-examples'
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem16g'
+        label 'kie-rhel7 && kie-mem16g && !master'
     }
     tools {
         maven 'kie-maven-3.8.1'

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -8,7 +8,7 @@ pipelineProperties = [:]
 
 pipeline {
     agent {
-        label 'kie-rhel7'
+        label 'kie-rhel7 && !master'
     }
 
     tools {

--- a/.ci/jenkins/dsl/Jenkinsfile.seed
+++ b/.ci/jenkins/dsl/Jenkinsfile.seed
@@ -1,7 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 seed_generation = null
-node('master') {
+node('kie-rhel8 && !master') {
     dir("${SEED_REPO}") {
         checkout(githubscm.resolveRepository("${SEED_REPO}", "${SEED_AUTHOR}", "${SEED_BRANCH}", false))
         seed_generation = load "${SEED_SCRIPTS_FILEPATH}"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7356

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/485
- https://github.com/kiegroup/kogito-runtimes/pull/2255
- https://github.com/kiegroup/kogito-examples/pull/1286
- https://github.com/kiegroup/kogito-images/pull/1276
- https://github.com/kiegroup/kogito-operator/pull/1205
- https://github.com/kiegroup/optaplanner/pull/2025
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/709
- https://github.com/kiegroup/optaweb-employee-rostering/pull/827
- https://github.com/kiegroup/optaplanner-quickstarts/pull/353