### PR TITLE
KOGITO-7455 Changed WireMockServer instances to use dynamic port

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/test/java/org/kogito/examples/sw/github/workflow/GitHubServiceMockServer.java
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/test/java/org/kogito/examples/sw/github/workflow/GitHubServiceMockServer.java
@@ -34,7 +34,7 @@ public class GitHubServiceMockServer implements QuarkusTestResourceLifecycleMana
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.options().port(8282));
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(post(urlEqualTo("/repo/your-username/your-repository/pr/2/labels"))

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/java/org/acme/newsletter/subscription/flow/SubscriptionServiceMock.java
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/java/org/acme/newsletter/subscription/flow/SubscriptionServiceMock.java
@@ -25,6 +25,7 @@ import org.acme.newsletter.subscription.service.SubscriptionResource;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 
@@ -47,7 +48,7 @@ public class SubscriptionServiceMock implements QuarkusTestResourceLifecycleMana
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8283);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
         configureFor(wireMockServer.port());
 

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/src/test/java/org/kogito/serverless/examples/RestCountriesMockServer.java
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/src/test/java/org/kogito/serverless/examples/RestCountriesMockServer.java
@@ -36,7 +36,7 @@ public class RestCountriesMockServer implements QuarkusTestResourceLifecycleMana
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.options().port(8282));
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         final ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-7455

Using fixed port numbers may cause unpredictable test failures due to port conflict.
This PR change examples that use WireMock to use dynamic port where possible.

-----

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-examples] mandrel</b>

</details>