### PR TITLE
[KOGITO-7504] Update Maven to 3.8.6

### DIFF
--- a/.github/workflows/kogito-examples-pr.yml
+++ b/.github/workflows/kogito-examples-pr.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Maven Build


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/543
- https://github.com/kiegroup/kogito-runtimes/pull/2317
- https://github.com/kiegroup/kogito-apps/pull/1407
- https://github.com/kiegroup/kogito-examples/pull/1324
- https://github.com/kiegroup/drools/pull/4525
- https://github.com/kiegroup/optaplanner/pull/2063
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/728
- https://github.com/kiegroup/optaweb-employee-rostering/pull/841