### PR TITLE
Avoiding error to appear in output

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-server-rpc-quarkus/src/main/java/org/kie/kogito/examples/sw/greeting/GreeterService.java
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-server-rpc-quarkus/src/main/java/org/kie/kogito/examples/sw/greeting/GreeterService.java
@@ -104,15 +104,17 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase {
     @Override
     public StreamObserver<HelloRequest> sayHelloMultipleLanguagesError(StreamObserver<HelloReply> responseObserver) {
         return new StreamObserver<>() {
-            int counter = 0;
-
+            int counter;
+            
             @Override
             public void onNext(HelloRequest helloRequest) {
-                responseObserver.onNext(HelloReply.newBuilder().setMessage(getMessage(helloRequest)).build());
-                if (++counter == 2) {
+                counter++;
+                if (counter == 2) {
+                    responseObserver.onNext(HelloReply.newBuilder().setMessage(getMessage(helloRequest)).build());
                     RuntimeException ex = Status.OUT_OF_RANGE.asRuntimeException();
                     responseObserver.onError(ex);
-                    throw ex;
+                } else if (counter < 2){
+                    responseObserver.onNext(HelloReply.newBuilder().setMessage(getMessage(helloRequest)).build());
                 }
             }
 
@@ -123,7 +125,9 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase {
 
             @Override
             public void onCompleted() {
-                responseObserver.onCompleted();
+                if (counter < 2) {
+                    responseObserver.onCompleted();
+                }
             }
         };
     }


### PR DESCRIPTION
This change aims to preven this trace to appear in err console

```
Aug 01, 2022 5:00:28 PM io.grpc.internal.SerializingExecutor run
SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1MessagesAvailable@2dd1d889
io.grpc.StatusRuntimeException: OUT_OF_RANGE
	at io.grpc.Status.asRuntimeException(Status.java:526)
	at org.kie.kogito.examples.sw.greeting.GreeterService$3.onNext(GreeterService.java:113)
	at org.kie.kogito.examples.sw.greeting.GreeterService$3.onNext(GreeterService.java:106)
	at io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onMessage(ServerCalls.java:262)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.messagesAvailableInternal(ServerCallImpl.java:318)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.messagesAvailable(ServerCallImpl.java:301)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1MessagesAvailable.runInContext(ServerImpl.java:834)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)

Aug 01, 2022 5:00:28 PM io.grpc.internal.SerializingExecutor run
SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@3a28fdfb
java.lang.IllegalStateException: call already closed
	at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
	at io.grpc.internal.ServerCallImpl.closeInternal(ServerCallImpl.java:214)
	at io.grpc.internal.ServerCallImpl.close(ServerCallImpl.java:207)
	at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onCompleted(ServerCalls.java:395)
	at org.kie.kogito.examples.sw.greeting.GreeterService$3.onCompleted(GreeterService.java:126)
	at io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onHalfClose(ServerCalls.java:273)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:340)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)


```