### PR TITLE
[KOGITO-7865] Adding custom type through addon example

### DIFF
--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -48,6 +48,7 @@
         <module>serverless-workflow-newsletter-subscription</module>
         <module>serverless-workflow-oauth2-orchestration-quarkus</module>
         <module>serverless-workflow-timeouts-showcase</module>
+        <module>serverless-workflow-custom-type</module>
       </modules>
     </profile>
 
@@ -85,6 +86,7 @@
         <module>serverless-workflow-oauth2-orchestration-quarkus</module>
         <module>serverless-workflow-service-calls-quarkus</module>
         <module>serverless-workflow-temperature-conversion</module>
+        <module>serverless-workflow-custom-type</module>
       </modules>
     </profile>
 

--- a/serverless-workflow-examples/serverless-workflow-custom-type/README.md
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/README.md
@@ -1,0 +1,5 @@
+# Kogito Serverless Workflow - custom type example
+
+The goal of this example is to illustrate definition of Serverless Workfow custom types
+
+

--- a/serverless-workflow-examples/serverless-workflow-custom-type/README.md
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/README.md
@@ -1,5 +1,5 @@
 # Kogito Serverless Workflow - custom type example
 
-The goal of this example is to illustrate definition of Serverless Workfow custom types
+The goal of this example is to illustrate definition of Serverless Workflow custom types
 
 

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kie.kogito.examples</groupId>
+  <artifactId>serverless-workflow-custom-type</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Kogito Example :: Serverless Workflow Custom type :: Quarkus</name>
+  
+  <properties>
+     <version.compiler.plugin>3.8.1</version.compiler.plugin>
+     <version.jar.plugin>3.1.0</version.jar.plugin> 
+     <quarkus-plugin.version>2.11.1.Final</quarkus-plugin.version>
+     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+     <quarkus.platform.version>2.11.1.Final</quarkus.platform.version>
+     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
+     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
+     <kogito.bom.version>${project.version}</kogito.bom.version>
+     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
+     <maven.compiler.release>11</maven.compiler.release>
+     <version.org.slf4j>1.7.30</version.org.slf4j>
+     <version.io.quarkus>2.11.1.Final</version.io.quarkus>
+   </properties>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>${kogito.bom.group-id}</groupId>
+        <artifactId>${kogito.bom.artifact-id}</artifactId>
+        <version>${kogito.bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  
+  <modules>
+    <module>serverless-workflow-custom-rpc-deployment</module>
+    <module>serverless-workflow-custom-rpc</module>
+    <module>serverless-workflow-custom-type-example</module>
+    <module>serverless-workflow-custom-rpc-server</module>
+  </modules>
+
+</project>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -12,17 +12,17 @@
   <properties>
      <version.compiler.plugin>3.8.1</version.compiler.plugin>
      <version.jar.plugin>3.1.0</version.jar.plugin> 
-     <quarkus-plugin.version>2.11.1.Final</quarkus-plugin.version>
+     <quarkus-plugin.version>2.12.0.Final</quarkus-plugin.version>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
      <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-     <quarkus.platform.version>2.11.1.Final</quarkus.platform.version>
+     <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
      <kogito.bom.version>${project.version}</kogito.bom.version>
      <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
      <maven.compiler.release>11</maven.compiler.release>
      <version.org.slf4j>1.7.30</version.org.slf4j>
-     <version.io.quarkus>2.11.1.Final</version.io.quarkus>
+     <version.io.quarkus>2.12.0.Final</version.io.quarkus>
    </properties>
   
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>serverless-workflow-custom-type</artifactId>
+    <groupId>org.kie.kogito.examples</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>serverless-workflow-custom-rpc-deployment</artifactId>
+  <name>Kogito Example:: Serverless Workflow Custom RPC:: deployment</name>
+  <description>Custom addon to add custom rpc support</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito.examples</groupId>
+      <artifactId>serverless-workflow-custom-rpc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-serverless-workflow-deployment</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+                <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomFunctionNamespace.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomFunctionNamespace.java
@@ -1,0 +1,29 @@
+package org.kie.kogito.examples.sw.services;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.kie.kogito.serverless.workflow.functions.WorkItemFunctionNamespace;
+import org.kie.kogito.serverless.workflow.parser.ParserContext;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionRef;
+
+import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.NAME;
+import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.OPERATION;
+import static org.kie.kogito.serverless.workflow.parser.FunctionNamespaceFactory.getFunctionName;
+
+public class RPCCustomFunctionNamespace extends WorkItemFunctionNamespace{
+
+    @Override
+    public String namespace() {
+        return "rpc";
+    }
+
+    @Override
+    protected <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(Workflow workflow,
+                                                                                                        ParserContext context,
+                                                                                                        WorkItemNodeFactory<T> node,
+                                                                                                        FunctionRef functionRef) {
+        return node.workName(NAME).metaData(OPERATION,  getFunctionName(functionRef));
+    }
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomFunctionNamespace.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomFunctionNamespace.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.examples.sw.services;
 
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java
@@ -1,0 +1,30 @@
+package org.kie.kogito.examples.sw.services;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.kie.kogito.serverless.workflow.parser.ParserContext;
+import org.kie.kogito.serverless.workflow.parser.types.WorkItemTypeHandler;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+
+import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.NAME;
+import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.OPERATION;
+import static org.kie.kogito.serverless.workflow.parser.FunctionTypeHandlerFactory.trimCustomOperation;
+
+public class RPCCustomTypeHandler extends WorkItemTypeHandler{
+
+
+    @Override
+    public String type() {
+        return "rpc";
+    }
+
+    @Override
+    protected <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(Workflow workflow,
+                                                                                                        ParserContext context,
+                                                                                                        WorkItemNodeFactory<T> node,
+                                                                                                        FunctionDefinition functionDef) {
+        return node.workName(NAME).metaData(OPERATION, trimCustomOperation(functionDef));
+    }
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.examples.sw.services;
 
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionNamespace
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionNamespace
@@ -1,0 +1,1 @@
+org.kie.kogito.examples.sw.services.RPCCustomFunctionNamespace

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionTypeHandler
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionTypeHandler
@@ -1,0 +1,1 @@
+org.kie.kogito.examples.sw.services.RPCCustomTypeHandler

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/README.md
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/README.md
@@ -1,0 +1,3 @@
+# Kogito Serverless Workflow - custom rest server
+
+A custom rpc calculator service for demo purposes

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/pom.xml
@@ -12,12 +12,11 @@
   <description>Custom RPC server</description>
   
   <dependencies>
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-api</artifactId>
-  </dependency>
-  
-     <dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -28,14 +27,6 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.compiler.plugin}</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.15</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.kogito.examples</groupId>
+    <artifactId>serverless-workflow-custom-type</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>serverless-workflow-custom-rpc-server</artifactId>
+  <name>Kogito Example :: Serverless Workflow Custom RPC Server :: Quarkus</name>
+  <description>Custom RPC server</description>
+  
+  <dependencies>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+  </dependency>
+  
+     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.15</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.examples.sw.custom;
 
 import java.io.DataInputStream;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java
@@ -1,0 +1,54 @@
+package org.kie.kogito.examples.sw.custom;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+public class CalculatorClient {
+    
+    public enum OperationId {
+        ADD (1),
+        SUBTRACTION(2),
+        MULTIPLICATION(3),
+        DIVISION(4),
+        UNKNOWN(-1);
+        
+        
+        private final byte opCode;
+        
+        private OperationId(int opCode) {
+            this.opCode = (byte)opCode;
+        }
+
+        public byte getOpCode() {
+            return opCode;
+        }
+
+    }
+    
+    public static int invokeOperation (String host, int port, OperationId operationId, int value1, int value2) throws IOException {
+        
+        try (Socket socket = new Socket(host,port)) 
+        {
+            DataOutputStream out = new DataOutputStream (socket.getOutputStream());
+            out.writeByte(operationId.getOpCode());
+            out.writeInt(value1);
+            out.writeInt(value2);
+        
+            DataInputStream in = new DataInputStream(socket.getInputStream());
+            switch (in.readByte()) {
+                case 0: 
+                    return in.readInt();
+                case -1:
+                    throw new UnsupportedOperationException(operationId.toString());
+                case -2: 
+                    throw new IllegalStateException("wrong message format");
+                default:
+                    throw new IllegalStateException("unknown response error code");
+                 
+            }
+        }
+    }
+ 
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorServer.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorServer.java
@@ -81,7 +81,7 @@ public class CalculatorServer implements Runnable, Closeable {
                 }
             }
             catch (IOException io) {
-                logger.error("Error writting to client",io);
+                logger.error("Error writing to client",io);
             }
         }
     }

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorServer.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorServer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples.sw.custom;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CalculatorServer implements Runnable, Closeable {
+    
+    private static final Logger logger = LoggerFactory.getLogger(CalculatorServer.class);
+
+    public static void main(String[] args) throws IOException  {
+       int port = args.length >= 1 ? Integer.parseInt(args[0]) : 8082;
+       try (CalculatorServer server = new CalculatorServer(port)) {
+         server.run();
+       } 
+    }
+           
+    private final ServerSocket socket;
+    
+    public CalculatorServer (int port) throws IOException  {
+        this.socket = new ServerSocket(port);
+        new Thread(this).start();
+    }
+    
+    @Override
+    public void run() {  
+         // old single thread server
+        while (!socket.isClosed()) {
+            try (Socket conn = socket.accept()) {
+                DataInputStream in = new DataInputStream(conn.getInputStream());
+                byte opCode = in.readByte();
+                int result = 0;
+                int errorCode = 0;
+                try {
+                    switch (opCode) {
+                        case 1: // add
+                            result = in.readInt() + in.readInt();
+                            break;
+                        case 2: // subtraction
+                            result = in.readInt() - in.readInt();
+                            break;
+                        case 3: // multiplication
+                            result = in.readInt() * in.readInt();
+                            break;
+                        case 4: //division 
+                            result = in.readInt() / in.readInt();
+                            break;
+                        default:
+                            //unrecognized
+                            errorCode = -1;
+                    }
+                } catch (IOException io) {
+                    errorCode = -2;
+                }
+                DataOutputStream out = new DataOutputStream(conn.getOutputStream());
+                out.writeByte(errorCode);
+                if (errorCode == 0) {
+                    out.writeInt(result);
+                }
+            }
+            catch (IOException io) {
+                logger.error("Error writting to client",io);
+            }
+        }
+    }
+    
+    @Override
+    public void close () throws IOException {
+        socket.close();
+    }
+  }
+

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/test/java/CalculatorClientTest.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/test/java/CalculatorClientTest.java
@@ -1,0 +1,36 @@
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.examples.sw.custom.CalculatorClient;
+import org.kie.kogito.examples.sw.custom.CalculatorServer;
+import org.kie.kogito.examples.sw.custom.CalculatorClient.OperationId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalculatorClientTest {
+    
+    
+    private static CalculatorServer server; 
+    
+    @BeforeAll 
+    static void init() throws IOException
+    {
+        server = new CalculatorServer(8082);
+    }
+    
+    
+    @AfterAll static void cleanup () throws IOException{
+        server.close();
+    }
+    
+    @Test
+    void testCalculator() throws IOException { 
+        assertEquals(7,CalculatorClient.invokeOperation("localhost", 8082, OperationId.ADD, 4, 3));
+        assertEquals(1,CalculatorClient.invokeOperation("localhost", 8082, OperationId.SUBTRACTION, 4, 3));
+        assertEquals(12,CalculatorClient.invokeOperation("localhost", 8082, OperationId.MULTIPLICATION, 4, 3));
+        assertEquals(1,CalculatorClient.invokeOperation("localhost", 8082, OperationId.DIVISION, 4, 3));
+    }
+
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/test/java/org/kie/kogito/examples/sw/custom/CalculatorClientTest.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/test/java/org/kie/kogito/examples/sw/custom/CalculatorClientTest.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples.sw.custom;
+
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.examples.sw.custom.CalculatorClient;
-import org.kie.kogito.examples.sw.custom.CalculatorServer;
 import org.kie.kogito.examples.sw.custom.CalculatorClient.OperationId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/pom.xml
@@ -14,7 +14,7 @@
   <description>Runtime counterpart for custom rpc type</description>
 
   <dependencies>
-   <dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-serverless-workflow</artifactId>
     </dependency>
@@ -25,9 +25,8 @@
     </dependency>
   </dependencies>
   <build>
-   
     <plugins>
-        <plugin>
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus-plugin.version}</version>
@@ -46,15 +45,15 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.compiler.plugin}</version>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.quarkus</groupId>
-              <artifactId>quarkus-extension-processor</artifactId>
-              <version>${version.io.quarkus}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-processor</artifactId>
+                <version>${version.io.quarkus}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
       </plugin>
     </plugins>
   </build>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>serverless-workflow-custom-type</artifactId>
+    <groupId>org.kie.kogito.examples</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>serverless-workflow-custom-rpc</artifactId>
+  <name>Kogito Example:: Serverless Workflow Custom RPC :: Runtime</name>
+  <description>Runtime counterpart for custom rpc type</description>
+
+  <dependencies>
+   <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-serverless-workflow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito.examples</groupId>
+      <artifactId>serverless-workflow-custom-rpc-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+   
+    <plugins>
+        <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
@@ -1,0 +1,43 @@
+package org.kie.kogito.examples.sw.custom;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.kogito.examples.sw.custom.CalculatorClient.OperationId;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.serverless.workflow.WorkflowWorkItemHandler;
+
+
+@ApplicationScoped
+public class RPCCustomWorkItemHandler extends WorkflowWorkItemHandler {
+
+    public final static String NAME = "RPCCustomWorkItemHandler";
+    public final static String HOST = "host";
+    public final static String PORT = "port";
+    public final static String OPERATION = "operation";
+    
+    @Override
+    protected Object internalExecute(KogitoWorkItem workItem, Map<String, Object> parameters)  {
+        try {
+            Iterator<?> iter = parameters.values().iterator();
+            Map<String, Object> metadata = workItem.getNodeInstance().getNode().getMetaData();
+            String operationId = (String) metadata.get(OPERATION);
+            if (operationId == null) {
+                throw new IllegalArgumentException ("Operation is a mandatory parameter");
+            }
+            return CalculatorClient.invokeOperation((String)metadata.getOrDefault(HOST,"localhost"), (int) metadata.getOrDefault(PORT, 8082), 
+                    OperationId.valueOf(OperationId.class, operationId.toUpperCase()), (Integer)iter.next(), (Integer)iter.next());
+        } catch (IOException io ) {
+            throw new UncheckedIOException(io);
+        }
+    }
+    
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
@@ -15,10 +15,10 @@ import org.kie.kogito.serverless.workflow.WorkflowWorkItemHandler;
 @ApplicationScoped
 public class RPCCustomWorkItemHandler extends WorkflowWorkItemHandler {
 
-    public final static String NAME = "RPCCustomWorkItemHandler";
-    public final static String HOST = "host";
-    public final static String PORT = "port";
-    public final static String OPERATION = "operation";
+    public static final String NAME = "RPCCustomWorkItemHandler";
+    public static final String HOST = "host";
+    public static final String PORT = "port";
+    public static final String OPERATION = "operation";
     
     @Override
     protected Object internalExecute(KogitoWorkItem workItem, Map<String, Object> parameters)  {
@@ -30,7 +30,7 @@ public class RPCCustomWorkItemHandler extends WorkflowWorkItemHandler {
                 throw new IllegalArgumentException ("Operation is a mandatory parameter");
             }
             return CalculatorClient.invokeOperation((String)metadata.getOrDefault(HOST,"localhost"), (int) metadata.getOrDefault(PORT, 8082), 
-                    OperationId.valueOf(OperationId.class, operationId.toUpperCase()), (Integer)iter.next(), (Integer)iter.next());
+                    OperationId.valueOf(operationId.toUpperCase()), (Integer)iter.next(), (Integer)iter.next());
         } catch (IOException io ) {
             throw new UncheckedIOException(io);
         }

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.examples.sw.custom;
 
 import java.io.IOException;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.examples.sw.custom;
 
 import javax.annotation.PostConstruct;

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java
@@ -1,0 +1,20 @@
+package org.kie.kogito.examples.sw.custom;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.kogito.process.impl.CachedWorkItemHandlerConfig;
+
+
+@ApplicationScoped
+public class RPCCustomWorkItemHandlerConfig extends CachedWorkItemHandlerConfig {
+    
+    @Inject
+    RPCCustomWorkItemHandler handler;
+    
+    @PostConstruct
+    void init () {
+        register(handler.getName(),handler);
+    }
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/README.md
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/README.md
@@ -1,0 +1,3 @@
+# Kogito Serverless Workflow - Custom type example
+
+An example using custom rest type. 

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>serverless-workflow-custom-type</artifactId>
+    <groupId>org.kie.kogito.examples</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>serverless-workflow-custom-type-example</artifactId>
+ 
+
+  <name>Kogito Example :: Serverless Workflow Custom RPC Client :: Quarkus</name>
+  <description>The client project</description>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-serverless-workflow</artifactId>
+    </dependency>
+     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.kie.kogito.examples</groupId>
+      <artifactId>serverless-workflow-custom-rpc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.failsafe.plugin}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# Packaging
+# quarkus.package.type=fast-jar
+quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customFunction.sw.json
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customFunction.sw.json
@@ -1,0 +1,26 @@
+{
+  "id": "customFunction",
+  "version": "1.0",
+  "name": "Custom RPC example",
+  "description": "This test a custom function can be added as addon in the classpath",
+  "start": "start",
+  "states": [
+    {
+      "name": "start",
+      "type": "operation",
+      "actions": [
+       {
+          "functionRef": {
+             "refName": "rpc:division",
+             "arguments": {
+                 "dividend": ".dividend",
+                 "divisor" : ".divisor"
+             }
+           }
+          
+       }
+      ],
+      "end": true
+ 	}
+  ]
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customType.sw.json
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customType.sw.json
@@ -1,0 +1,33 @@
+{
+  "id": "customType",
+  "version": "1.0",
+  "name": "Custom RPC example",
+  "description": "This test a custom type can be added as addon in the classpath",
+  "start": "start",
+  "functions": [
+    {
+      "name": "division",
+      "type": "custom",
+      "operation": "rpc:division"
+    }
+  ],
+  "states": [
+    {
+      "name": "start",
+      "type": "operation",
+      "actions": [
+       {
+          "functionRef": {
+             "refName": "division",
+             "arguments": {
+                 "dividend": ".dividend",
+                 "divisor" : ".divisor"
+             }
+           }
+          
+       }
+      ],
+      "end": true
+ 	}
+  ]
+}

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/test/java/org/kie/kogito/examples/CustomRestIT.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/test/java/org/kie/kogito/examples/CustomRestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,13 @@ class CustomRestIT {
     private static CalculatorServer server; 
     
     @BeforeAll 
-    static void init() throws IOException
-    {
+    static void init() throws IOException {
         server = new CalculatorServer(8082);
     }
     
     
-    @AfterAll static void cleanup () throws IOException{
+    @AfterAll 
+    static void cleanup () throws IOException {
         server.close();
     }
     

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/test/java/org/kie/kogito/examples/CustomRestIT.java
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/test/java/org/kie/kogito/examples/CustomRestIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.examples;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.examples.sw.custom.CalculatorServer;
+import org.kie.kogito.serverless.workflow.SWFConstants;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusIntegrationTest
+class CustomRestIT {
+
+    private static CalculatorServer server; 
+    
+    @BeforeAll 
+    static void init() throws IOException
+    {
+        server = new CalculatorServer(8082);
+    }
+    
+    
+    @AfterAll static void cleanup () throws IOException{
+        server.close();
+    }
+    
+    
+    @Test
+    void testCustomType() {
+        testIt("customType");
+    }
+    
+    @Test
+    void testCustomFunction() {
+        testIt("customFunction");
+    }
+    
+
+    private void testIt(String path) {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(Map.of(SWFConstants.DEFAULT_WORKFLOW_VAR, Map.of("dividend", 4, "divisor", 3)))
+                .post(path)
+                .then()
+                .statusCode(201)
+                .body("workflowdata.response", is(1));
+    }
+}


### PR DESCRIPTION
This example illustrate the addition of custom type and custom functions through an addon. 
We are assuming the workflow wants to communicate with an external service written with a custom RPC protocol, then we add a new custom type "rpc" and also a custom namepsace "rpc" with two flows using them