### PR TITLE
Remove unnecessary extension kogito-addons-quarkus-persistence-jdbc

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/pom.xml
@@ -173,10 +173,6 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>kogito-addons-quarkus-persistence-jdbc</artifactId>
-        </dependency>
-        <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>


### PR DESCRIPTION
Need to be removed due to capability check now enabled in https://github.com/kiegroup/kogito-runtimes/pull/2442. Doesnt seems to be used anyway.