### PR TITLE
[KOGITO-7843] Adding http-connector properties to examples

### DIFF
--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/main/resources/application.properties
@@ -2,6 +2,9 @@
 # quarkus.package.type=fast-jar
 quarkus.swagger-ui.always-include=true
 
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
 mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 # localhost URL to work as a fallback in case the env is not defined in the pod yet. To be handled by: https://issues.redhat.com/browse/KOGITO-6523
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/test/java/org/kie/kogito/examples/CloudEventListenerTest.java
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/test/java/org/kie/kogito/examples/CloudEventListenerTest.java
@@ -81,7 +81,7 @@ public class CloudEventListenerTest {
                 .header("ce-kogitodmnmodelname", KOGITO_MODEL_NAME)
                 .header("ce-kogitodmnmodelnamespace", KOGITO_MODEL_NAMESPACE)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(new ObjectMapper().writeValueAsString(decisionInput)).post("/").then().statusCode(200);
+                .body(new ObjectMapper().writeValueAsString(decisionInput)).post("/").then().statusCode(202);
 
         await()
                 .atLeast(2, SECONDS)

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/main/resources/application.properties
@@ -3,6 +3,10 @@
 
 quarkus.swagger-ui.always-include=true
 
+
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
 
 kogito.messaging.as-cloudevents=true

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/test/java/org/acme/travel/CloudEventListenerTest.java
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/test/java/org/acme/travel/CloudEventListenerTest.java
@@ -79,7 +79,7 @@ public class CloudEventListenerTest {
                 .header("ce-source", "/from/test")
                 .header("ce-type", "travellers")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(200);
+                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(202);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class CloudEventListenerTest {
                 .header("ce-source", "/from/test")
                 .header("ce-type", "travellers")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(200);
+                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(202);
 
         LOGGER.info("Waiting at most 2 seconds to receive the produced message");
         await().atMost(2, SECONDS).untilAsserted(() -> sink.verify(1, postRequestedFor(urlEqualTo("/"))
@@ -121,7 +121,7 @@ public class CloudEventListenerTest {
                 .header("ce-source", "travellers")
                 .header("ce-type", "whatevertype")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(200);
+                .body(objectMapper.writeValueAsString(traveller)).post("/").then().statusCode(202);
 
         LOGGER.info("Waiting at most 2 seconds to receive the produced message");
         await().atMost(2, SECONDS).untilAsserted(() -> sink.verify(1, postRequestedFor(urlEqualTo("/"))

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -20,6 +20,7 @@
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
+    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>
@@ -78,6 +79,12 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-test-utils</artifactId>
+      <version>${version.org.kie.kogito}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/src/main/resources/application.properties
@@ -20,4 +20,6 @@ mp.messaging.outgoing.out-applicants.topic=applicants
 mp.messaging.outgoing.out-applicants.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.out-applicants.group.id=kogito-sw-applicants-out
 
+quarkus.devservices.enabled=false
+
 quarkus.native.native-image-xmx=8g

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
@@ -10,6 +10,9 @@ kogito.sw.functions.AssignDoctorToPatient.port=${quarkus.http.port:8080}
 kogito.sw.functions.SchedulePatientAppointment.host=localhost
 kogito.sw.functions.SchedulePatientAppointment.port=${quarkus.http.port:8080}
 
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
 # The K_SINK variable will be injected for us by the KogitoSource
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
 

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/test/java/org/acme/sw/onboarding/resources/OnboardingIT.java
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/test/java/org/acme/sw/onboarding/resources/OnboardingIT.java
@@ -28,7 +28,8 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 @QuarkusIntegrationTest
 class OnboardingIT {
@@ -53,7 +54,7 @@ class OnboardingIT {
                 .when()
                 .post("/")
                 .then()
-                .statusCode(200);
+                .statusCode(202);
 
         await().atMost(Duration.ofMinutes(1)).untilAsserted(() -> given()
                 .contentType(MediaType.APPLICATION_JSON)

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
@@ -4,6 +4,10 @@ quarkus.swagger-ui.always-include=true
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/url=${GITHUB_SERVICE_URI}
 org.kogito.examples.sw.github.workflow.GitHubClient/mp-rest/scope=javax.inject.Singleton
 
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
+
 mp.messaging.outgoing.pr_verified.connector=quarkus-http
 mp.messaging.outgoing.pr_verified.url=${K_SINK}
 

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/test/java/org/kogito/examples/sw/github/workflow/PRCheckerWorkflowTest.java
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/test/java/org/kogito/examples/sw/github/workflow/PRCheckerWorkflowTest.java
@@ -46,6 +46,6 @@ class PRCheckerWorkflowTest {
 
         given()
                 .contentType(JsonFormat.CONTENT_TYPE)
-                .body(pullRequestEvent).post("/").then().statusCode(200);
+                .body(pullRequestEvent).post("/").then().statusCode(202);
     }
 }

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
@@ -5,6 +5,9 @@ quarkus.log.category."org.kie.kogito.addon.quarkus.messaging".level=DEBUG
 # The generated OpenAPI, the local 8181 is for playing locally, otherwise in the cluster, we will have a env var injected
 quarkus.rest-client.subscription_service_yaml.url=${SUBSCRIPTION_API_URL:http://localhost:8282}
 
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
 # The K_SINK variable will be injected for us by the Knative
 mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/java/org/acme/newsletter/subscription/flow/SubscriptionFlowIT.java
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/java/org/acme/newsletter/subscription/flow/SubscriptionFlowIT.java
@@ -100,7 +100,7 @@ public class SubscriptionFlowIT {
                 .body(mapper.writeValueAsString(subscription))
                 .post("/")// the root path means we are listening for CEs for Knative Eventing integration
                 .then()
-                .statusCode(200);
+                .statusCode(202);
 
         // the workflow should emit a new event indicating that the subscription was successful!
         await()

--- a/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
@@ -3,6 +3,9 @@ quarkus.log.level=INFO
 # The K_SINK variable will be injected for us by the KogitoSource
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
 
+mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
+mp.messaging.incoming.kogito_incoming_stream.path=/
+
 quarkus.container-image.group=kogito
 
 # this enables Knative to fetch the image information on Minikube.

--- a/serverless-workflow-examples/serverless-workflow-order-processing/src/test/java/org/kie/kogito/examples/sw/orders/processing/VerifyWorkflowExecutionIT.java
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/src/test/java/org/kie/kogito/examples/sw/orders/processing/VerifyWorkflowExecutionIT.java
@@ -84,7 +84,7 @@ public class VerifyWorkflowExecutionIT {
                 .body(objectMapper.writeValueAsString(order))
                 .post("/")
                 .then()
-                .statusCode(200);
+                .statusCode(202);
 
         await()
                 .atMost(60, SECONDS)
@@ -114,7 +114,7 @@ public class VerifyWorkflowExecutionIT {
                 .body(objectMapper.writeValueAsString(order))
                 .post("/")
                 .then()
-                .statusCode(200);
+                .statusCode(202);
 
         await()
                 .atMost(60, SECONDS)
@@ -144,7 +144,7 @@ public class VerifyWorkflowExecutionIT {
                 .body(objectMapper.writeValueAsString(order))
                 .post("/")
                 .then()
-                .statusCode(200);
+                .statusCode(202);
 
         await()
                 .atMost(60, SECONDS)


### PR DESCRIPTION
Except for one example, where we were using both http and kafka at the same time (this is not longer supporter, so I changed the test to use Kafka rather than HTTP to resume the workflow) the rest of the changes are configuration for the default channel and 202 http code rather than 200. 

Depends on https://github.com/kiegroup/kogito-runtimes/pull/2448