### PR TITLE
[KOGITO-8068] Updating decission examples to use lenient check

### DIFF
--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/src/test/java/org/kie/kogito/examples/DmnEventDrivenIT.java
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/src/test/java/org/kie/kogito/examples/DmnEventDrivenIT.java
@@ -153,7 +153,7 @@ public class DmnEventDrivenIT {
             LOG.debug("Normalized actual..: " + normalizedActualJson);
         }
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/src/test/java/org/kie/kogito/examples/PmmlEventDrivenIT.java
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/src/test/java/org/kie/kogito/examples/PmmlEventDrivenIT.java
@@ -167,7 +167,7 @@ public class PmmlEventDrivenIT {
         LOG.info("Normalized expected: " + normalizedExpectedJson);
         LOG.info("Normalized actual..: " + normalizedActualJson);
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/src/test/java/org/kie/kogito/examples/RuleUnitEventDrivenIT.java
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/src/test/java/org/kie/kogito/examples/RuleUnitEventDrivenIT.java
@@ -144,7 +144,7 @@ class RuleUnitEventDrivenIT {
             LOG.debug("Normalized actual..: " + normalizedActualJson);
         }
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {

--- a/kogito-springboot-examples/dmn-event-driven-springboot/src/test/java/org/kie/kogito/examples/DmnEventDrivenIT.java
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/src/test/java/org/kie/kogito/examples/DmnEventDrivenIT.java
@@ -137,7 +137,7 @@ public class DmnEventDrivenIT {
             LOG.debug("Normalized actual..: " + normalizedActualJson);
         }
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {

--- a/kogito-springboot-examples/pmml-event-driven-springboot/src/test/java/org/kie/kogito/examples/PmmlEventDrivenIT.java
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/src/test/java/org/kie/kogito/examples/PmmlEventDrivenIT.java
@@ -151,7 +151,7 @@ class PmmlEventDrivenIT {
         LOG.info("Normalized expected: " + normalizedExpectedJson);
         LOG.info("Normalized actual..: " + normalizedActualJson);
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/src/test/java/org/kie/kogito/examples/RuleUnitEventDrivenIT.java
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/src/test/java/org/kie/kogito/examples/RuleUnitEventDrivenIT.java
@@ -128,7 +128,7 @@ class RuleUnitEventDrivenIT {
             LOG.debug("Normalized actual..: " + normalizedActualJson);
         }
 
-        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(normalizedExpectedJson, normalizedActualJson, JSONCompareMode.LENIENT);
     }
 
     private void doTest(String basePath) {


### PR DESCRIPTION
This is needed because time cannot be precalculated. And in general, the check should be lenient because we do not really care about order or about additional properties, we just need that the values of the properties present matches the expected ones.

Merge with https://github.com/kiegroup/kogito-runtimes/pull/2575