### PR TITLE
KOGITO-8417 Enforced Maven version configuration.

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -372,7 +372,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
 }
 
 MavenCommand getMavenCommand(String directory = '') {
-    directory = directory ?: getRepoName()
     MavenCommand mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
                                 .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                                 .withProperty('full')

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -115,7 +115,9 @@ pipeline {
         stage('Build kogito-examples') {
             steps {
                 script {
-                    getMavenCommand().withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
+                    dir(getRepoName()) {
+                        getMavenCommand().withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
+                    }
                 }
             }
             post {
@@ -133,12 +135,15 @@ pipeline {
             }
             steps {
                 script {
-                    sh "cp -r ${getRepoName()} ${getRepoName()}-persistence"
-                    getMavenCommand("${getRepoName()}-persistence")
-                        .skipTests(params.SKIP_TESTS)
-                        .withProfiles(['persistence'])
-                        .withProperty('maven.test.failure.ignore', true)
-                        .run('clean install')
+                    String newDir = "${getRepoName()}-persistence"
+                    sh "cp -r ${getRepoName()} ${newDir}"
+                    dir(newDir) {
+                        getMavenCommand()
+                            .skipTests(params.SKIP_TESTS)
+                            .withProfiles(['persistence'])
+                            .withProperty('maven.test.failure.ignore', true)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -156,12 +161,15 @@ pipeline {
             }
             steps {
                 script {
-                    sh "cp -r ${getRepoName()} ${getRepoName()}-events"
-                    getMavenCommand("${getRepoName()}-events")
-                        .skipTests(params.SKIP_TESTS)
-                        .withProfiles(['events'])
-                        .withProperty('maven.test.failure.ignore', true)
-                        .run('clean install')
+                    String newDir = "${getRepoName()}-events"
+                    sh "cp -r ${getRepoName()} ${newDir}"
+                    dir(newDir) {
+                        getMavenCommand()
+                            .skipTests(params.SKIP_TESTS)
+                            .withProfiles(['events'])
+                            .withProperty('maven.test.failure.ignore', true)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -179,7 +187,9 @@ pipeline {
             }
             steps {
                 script {
-                    runMavenDeploy()
+                    dir(getRepoName()) {
+                        runMavenDeploy()
+                    }
                 }
             }
         }
@@ -189,7 +199,9 @@ pipeline {
             }
             steps {
                 script {
-                    runMavenDeploy(true)
+                    dir(getRepoName()) {
+                        runMavenDeploy(true)
+                    }
                 }
             }
         }
@@ -199,8 +211,10 @@ pipeline {
             }
             steps {
                 script {
-                    // Deploy to specific repository with credentials
-                    maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(), getMavenRepoZipUrl())
+                    dir(getRepoName()) {
+                        // Deploy to specific repository with credentials
+                        maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(), getMavenRepoZipUrl())
+                    }
                 }
             }
         }
@@ -210,8 +224,10 @@ pipeline {
             }
             steps {
                 script {
-                    // Stage release artifacts
-                    runMavenStage()
+                    dir(getRepoName()) {
+                        // Stage release artifacts
+                        runMavenStage()
+                    }
                 }
             }
         }
@@ -371,13 +387,10 @@ void setDeployPropertyIfNeeded(String key, def value) {
     }
 }
 
-MavenCommand getMavenCommand(String directory = '') {
+MavenCommand getMavenCommand() {
     MavenCommand mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
                                 .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                                 .withProperty('full')
-    if (directory) {
-        mvnCmd.inDirectory(directory)
-    }
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
         mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -63,7 +63,9 @@ pipeline {
                         }
                     }
 
-                    checkoutRepo()
+                    dir(getRepoName()) {
+                        checkoutRepo()
+                    }
                 }
             }
             post {
@@ -84,7 +86,11 @@ pipeline {
                 expression { return isRelease() || isCreatePr() }
             }
             steps {
-                prepareForPR()
+                script {
+                    dir(getRepoName()) {
+                        prepareForPR()
+                    }
+                }
             }
         }
         stage('Update project version') {
@@ -236,12 +242,16 @@ pipeline {
                 expression { return isRelease() || isCreatePr() }
             }
             steps {
-                commitAndCreatePR()
-                
-                setDeployPropertyIfNeeded("${getRepoName()}.pr.source.uri", "https://github.com/${getBotAuthor()}/${getRepoName()}")
-                setDeployPropertyIfNeeded("${getRepoName()}.pr.source.ref", getBotBranch())
-                setDeployPropertyIfNeeded("${getRepoName()}.pr.target.uri", "https://github.com/${getGitAuthor()}/${getRepoName()}")
-                setDeployPropertyIfNeeded("${getRepoName()}.pr.target.ref", getBuildBranch())
+                script {
+                    dir(getRepoName()) {
+                        commitAndCreatePR()
+
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.source.uri", "https://github.com/${getBotAuthor()}/${getRepoName()}")
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.source.ref", getBotBranch())
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.target.uri", "https://github.com/${getGitAuthor()}/${getRepoName()}")
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.target.ref", getBuildBranch())
+                    }
+                }
             }
         }
     }
@@ -277,17 +287,13 @@ void saveReports() {
 }
 
 void checkoutRepo() {
-    dir(getRepoName()) {
-        deleteDir()
-        checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
-    }
+    deleteDir()
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
 }
 
 void prepareForPR() {
-    dir(getRepoName()) {
-        githubscm.forkRepo(getBotAuthorCredsID())
-        githubscm.createBranch(getBotBranch())
-    }
+    githubscm.forkRepo(getBotAuthorCredsID())
+    githubscm.createBranch(getBotBranch())
 }
 
 void addNotIgnoredPoms() {
@@ -316,12 +322,10 @@ void commitAndCreatePR() {
     }
     // Not using githubscm.commitChanges() because globbing won't work.
     // See: https://github.com/kiegroup/kogito-runtimes/pull/570#discussion_r449268738
-    dir(getRepoName()) {
-        addNotIgnoredPoms()
-        sh "git commit -m '${commitMsg}'"
-        githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
-        deployProperties["${getRepoName()}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
-    }
+    addNotIgnoredPoms()
+    sh "git commit -m '${commitMsg}'"
+    githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
+    deployProperties["${getRepoName()}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
 }
 
 boolean isSpecificArtifactsUpload() {
@@ -406,9 +410,7 @@ void runMavenDeploy(boolean localDeployment = false) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
-    dir(getRepoName()) {
-        mvnCmd.withOptions(examplesHelper.getDeployableArtifactIds().collect { "-pl :${it} "})
-    }
+    mvnCmd.withOptions(examplesHelper.getDeployableArtifactIds().collect { "-pl :${it} "})
 
     mvnCmd.skipTests(true).run('clean deploy')
 }

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
     <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
@@ -16,9 +16,9 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <version.org.drools>8.32.0.Final</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/Dockerfile
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE quarkus
 

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>
@@ -20,8 +20,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>dmn-knative-quickstart-quarkus</artifactId>
@@ -20,8 +20,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/Dockerfile
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE quarkus
 

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/docker-compose.yml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./docker-compose/infinispan/infinispan.xml:/opt/infinispan/server/conf/infinispan-demo.xml:z
 
   trusty:
-    image: quay.io/kiegroup/kogito-trusty-infinispan:latest
+    image: quay.io/kiegroup/kogito-trusty-infinispan:1.32
     depends_on:
       - kafka
       - infinispan

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>
@@ -18,9 +18,9 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <version.org.drools>8.32.0.Final</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-basic</artifactId>
   <name>Kogito Example :: Travel Agency :: Basic</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
     <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/docker-compose.yml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -109,7 +109,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - 8280:8080
     depends_on:
@@ -125,7 +125,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example-extended</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
@@ -16,9 +16,9 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <version.org.drools>8.32.0.Final</version.org.drools>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
     <version.org.drools>8.32.0-SNAPSHOT</version.org.drools>
   </properties>
   <dependencyManagement>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-travel-agency-example-extended</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/kogito-travel-agency/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>kogito-travel-agency-example</artifactId>
   <packaging>pom</packaging>

--- a/kogito-quarkus-examples/ocp-tryout/kogito-data-index/kogito-data-index.sh
+++ b/kogito-quarkus-examples/ocp-tryout/kogito-data-index/kogito-data-index.sh
@@ -18,7 +18,7 @@ elif [ "${action}" == "install" ]; then
   oc create configmap data-index-config --from-file=../testapp/protobuf -o yaml --dry-run=client | \
     oc label -f- --dry-run=client -o yaml --local=true app=kogito-data-index-"${type}" | \
     oc apply -f- -n $(getProjectName) $(dryRun)
-  oc new-app quay.io/kiegroup/kogito-data-index-"${type}":"${KOGITO_VERSION}" -n $(getProjectName) $(dryRun "NewApp")
+  oc new-app quay.io/kiegroup/kogito-data-index-"${type}":1.32
   waitForPod kogito-data-index
   oc patch deployment kogito-data-index-"${type}" --patch "$(cat deployment-patch-"${type}".yaml)" -n $(getProjectName) $(dryRun)
   waitForPod kogito-data-index

--- a/kogito-quarkus-examples/ocp-tryout/kogito-jobs-service/kogito-jobs-service.sh
+++ b/kogito-quarkus-examples/ocp-tryout/kogito-jobs-service/kogito-jobs-service.sh
@@ -9,7 +9,7 @@ if [ "${action}" == "uninstall" ]; then
 
 elif [ "${action}" == "install" ]; then
   echo "*** installing jobs service"
-  oc new-app quay.io/kiegroup/kogito-jobs-service-${type}:${KOGITO_VERSION} -n $(getProjectName) $(dryRun "NewApp")
+  oc new-app quay.io/kiegroup/kogito-jobs-service-${type}:1.32
   waitForPod kogito-jobs-service
   oc patch deployment kogito-jobs-service-${type} --patch "$(cat deployment-patch.yaml)" -n $(getProjectName) $(dryRun)
   waitForPod kogito-jobs-service

--- a/kogito-quarkus-examples/ocp-tryout/kogito-management-console/kogito-management-console.sh
+++ b/kogito-quarkus-examples/ocp-tryout/kogito-management-console/kogito-management-console.sh
@@ -17,7 +17,7 @@ elif [ "${action}" == "install" ]; then
   oc create configmap kogito-management-config --from-file=../testapp/svg -o yaml --dry-run=client | \
     oc label -f- --dry-run=client -o yaml --local=true app=kogito-management-console | \
     oc apply -f- -n $(getProjectName) $(dryRun)
-  oc new-app quay.io/kiegroup/kogito-management-console:"${KOGITO_VERSION}" -n $(getProjectName) $(dryRun "NewApp")
+  oc new-app quay.io/kiegroup/kogito-management-console:1.32
   waitForPod kogito-management-console
   oc patch deployment kogito-management-console --patch "$(cat deployment-patch.yaml)" -n $(getProjectName) $(dryRun)
   waitForPod kogito-management-console

--- a/kogito-quarkus-examples/ocp-tryout/kogito-task-console/kogito-task-console.sh
+++ b/kogito-quarkus-examples/ocp-tryout/kogito-task-console/kogito-task-console.sh
@@ -8,7 +8,7 @@ if [ "${action}" == "uninstall" ]; then
 
 elif [ "${action}" == "install" ]; then
   echo "*** installing task console"
-  oc new-app quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION} -n $(getProjectName) $(dryRun "NewApp")
+  oc new-app quay.io/kiegroup/kogito-task-console:1.32
   waitForPod kogito-task-console
   oc patch deployment kogito-task-console --patch "$(cat deployment-patch.yaml)" -n $(getProjectName) $(dryRun)
   waitForPod kogito-task-console

--- a/kogito-quarkus-examples/onboarding-example/hr/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/hr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/kogito-quarkus-examples/onboarding-example/hr/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/hr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>hr</artifactId>
   <name>Kogito Example :: Onboarding Example :: HR with Drools</name>

--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>onboarding-quarkus</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Quarkus</name>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>onboarding-example</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>payroll</artifactId>
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>

--- a/kogito-quarkus-examples/onboarding-example/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>
@@ -23,8 +23,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/onboarding-example/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-example</artifactId>
   <packaging>pom</packaging>
@@ -23,8 +23,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-examples</artifactId>

--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>kogito-quarkus-examples</artifactId>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-business-rules-quarkus</artifactId>
   <name>Kogito Example :: Process Business Rules Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-decisions-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-decisions-rest-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rest-quarkus</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-error-handling</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-infinispan-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-kafka-avro-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels, avro serialization</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-avro-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels, avro serialization</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-multi-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -35,8 +35,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -35,8 +35,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-kafka-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-knative-quickstart-quarkus</artifactId>
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-mongodb-persistence-quarkus</artifactId>
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/Dockerfile
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE quarkus
 

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-monitoring-quarkus</artifactId>
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-quarkus</artifactId>
@@ -21,8 +21,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
     </properties>
 
     <dependencyManagement>

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-quarkus-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.32.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-quarkus</artifactId>
@@ -21,8 +21,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
     </properties>
 
     <dependencyManagement>

--- a/kogito-quarkus-examples/process-performance-client/pom.xml
+++ b/kogito-quarkus-examples/process-performance-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-client</artifactId>
   <name>Kogito Example :: Client Performance test</name>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-client/pom.xml
+++ b/kogito-quarkus-examples/process-performance-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-performance-client</artifactId>
   <name>Kogito Example :: Client Performance test</name>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-performance-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-performance-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-performance-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-performance-quarkus</artifactId>
   <name>Kogito Example :: Quarkus Performance test</name>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>
@@ -22,8 +22,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-quarkus</artifactId>
@@ -22,8 +22,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-quarkus-example</artifactId>
   <name>Kogito Example :: Process and Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-rest-service-call-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-multi-quarkus</artifactId>
   <name>Kogito Example :: Process Rest :: Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-rest-workitem-quarkus</artifactId>
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <groupId>org.kie.kogito</groupId>
   <artifactId>process-saga-quarkus</artifactId>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <groupId>org.kie.kogito</groupId>
   <artifactId>process-saga-quarkus</artifactId>
@@ -19,8 +19,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-scripts-quarkus</artifactId>
   <name>Kogito Example :: Process Scripts With Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-service-calls-quarkus</artifactId>
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-timer-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-timer-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-timer-quarkus</artifactId>
   <name>Kogito Example :: Process Timer with Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-custom-lifecycle-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus-with-console/docker-compose/docker-compose-infinispan.yml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus-with-console/docker-compose/docker-compose-infinispan.yml
@@ -69,7 +69,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -87,7 +87,7 @@ services:
 
   management-console:
    container_name: management-console
-   image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+   image: quay.io/kiegroup/kogito-management-console:1.32
    ports:
      - 8280:8080
    depends_on:
@@ -103,7 +103,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-quarkus-examples/process-usertasks-quarkus-with-console/docker-compose/docker-compose-postgresql.yml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus-with-console/docker-compose/docker-compose-postgresql.yml
@@ -86,7 +86,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-postgresql:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-postgresql:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - "8280:8080"
     depends_on:
@@ -121,7 +121,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - "8380:8080"
     depends_on:

--- a/kogito-quarkus-examples/process-usertasks-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-quarkus-with-console</artifactId>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-quarkus-with-console</artifactId>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-quarkus</artifactId>
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose-infinispan.yml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose-infinispan.yml
@@ -69,7 +69,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -88,7 +88,7 @@ services:
   jobs-service:
     container_name: jobs-service
     network_mode: "host"
-    image: quay.io/kiegroup/kogito-jobs-service-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-jobs-service-infinispan:1.32
     depends_on:
       kafka:
         condition: service_started
@@ -105,7 +105,7 @@ services:
                          
   management-console:
    container_name: management-console
-   image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+   image: quay.io/kiegroup/kogito-management-console:1.32
    ports:
      - 8280:8080
    depends_on:
@@ -123,7 +123,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose-postgresql.yml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/docker-compose/docker-compose-postgresql.yml
@@ -86,7 +86,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-postgresql:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-postgresql:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   jobs-service:
     container_name: jobs-service
-    image: quay.io/kiegroup/kogito-jobs-service-postgresql:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-jobs-service-postgresql:1.32
     network_mode: "host"
     depends_on:
       - kafka
@@ -120,7 +120,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - "8280:8080"
     depends_on:
@@ -140,7 +140,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - "8380:8080"
     depends_on:

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus-with-console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-timer-quarkus-with-console</artifactId>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/docker-compose/docker-compose.yml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/docker-compose/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -87,7 +87,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - 8280:8080
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus-with-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus-with-console</artifactId>
   <name>Kogito Example :: Process Usertasks Security OIDC Keycloak Quarkus :: Console</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-oidc-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-usertasks-with-security-quarkus</artifactId>
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
@@ -17,8 +17,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
@@ -18,8 +18,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>ruleunit-quarkus-example</artifactId>
   <name>Kogito Example :: RuleUnit - Quarkus</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/trusty-demonstration/docker-compose/docker-compose.yml
+++ b/kogito-quarkus-examples/trusty-demonstration/docker-compose/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - kafka
 
   explainability:
-    image: quay.io/kiegroup/kogito-explainability:1.5
+    image: quay.io/kiegroup/kogito-explainability:1.32
     depends_on:
       - kafka
       - kogito-app
@@ -66,7 +66,7 @@ services:
       - 1336:8080
 
   trusty:
-    image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+    image: quay.io/kiegroup/kogito-trusty-infinispan:1.32
     depends_on:
       - kafka
       - infinispan
@@ -79,7 +79,7 @@ services:
       - 1337:8080
 
   trusty-ui:
-    image: quay.io/kiegroup/kogito-trusty-ui:1.5
+    image: quay.io/kiegroup/kogito-trusty-ui:1.32
     depends_on:
       - kafka
     environment:

--- a/kogito-quarkus-examples/trusty-demonstration/kubernetes/README.md
+++ b/kogito-quarkus-examples/trusty-demonstration/kubernetes/README.md
@@ -127,7 +127,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.4
+  image: quay.io/kiegroup/kogito-trusty-ui:1.32
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2:1337

--- a/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/explainability.yaml
+++ b/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/explainability.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   serviceType: Explainability
   replicas: 1
-  image: quay.io/kiegroup/kogito-explainability:1.5
+  image: quay.io/kiegroup/kogito-explainability:1.32
   infra:
     - kogito-kafka-infra

--- a/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
+++ b/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/trusty-ui.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceType: TrustyUI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-ui:1.5
+  image: quay.io/kiegroup/kogito-trusty-ui:1.32
   env:
     - name: KOGITO_TRUSTY_ENDPOINT
       value: http://172.17.0.2

--- a/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/trusty.yaml
+++ b/kogito-quarkus-examples/trusty-demonstration/kubernetes/resources/trusty.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceType: TrustyAI
   replicas: 1
-  image: quay.io/kiegroup/kogito-trusty-infinispan:1.5
+  image: quay.io/kiegroup/kogito-trusty-infinispan:1.32
   infra:
     - kogito-kafka-infra
     - kogito-infinispan-infra

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>trusty-tracing-quarkus-devservices</artifactId>
   <name>Kogito Example :: Trusty Tracing - Quarkus DevServices</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-quarkus-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>trusty-tracing-quarkus-devservices</artifactId>
   <name>Kogito Example :: Trusty Tracing - Quarkus DevServices</name>
@@ -16,8 +16,8 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>decisiontable-springboot-example</artifactId>
   <name>Kogito Example :: Decision Table - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/Dockerfile
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE springboot
 

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-drools-springboot-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics SpringBoot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-event-driven-springboot</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-listener-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-listener-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-listener-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-listener-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-listener-springboot</artifactId>
   <name>Kogito Example :: DMN with listeners - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-pmml-springboot-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-springboot-example/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-springboot-example/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-springboot-example</artifactId>
   <name>Kogito Example :: DMN - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-tracing-springboot/docker-compose.yml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./docker-compose/infinispan/infinispan.xml:/opt/infinispan/server/conf/infinispan-demo.xml:z
 
   trusty:
-    image: quay.io/kiegroup/kogito-trusty-nightly:latest
+    image: quay.io/kiegroup/kogito-trusty-nightly:1.32
     depends_on:
       - kafka
       - infinispan

--- a/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>dmn-tracing-springboot</artifactId>
   <name>Kogito Example :: DMN Tracing - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/flexible-process-springboot/pom.xml
+++ b/kogito-springboot-examples/flexible-process-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/flexible-process-springboot/pom.xml
+++ b/kogito-springboot-examples/flexible-process-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flexible-process-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>onboarding-springboot</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Spring Boot</name>
   <description>Onboarding function and service orchestration</description>
   
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>onboarding-springboot</artifactId>
   <name>Kogito Example :: Onboarding Example :: Onboarding with Business Process Spring Boot</name>
   <description>Onboarding function and service orchestration</description>
   
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>${version.org.kie.kogito}</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-event-driven-springboot</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/pmml-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/pmml-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>pmml-springboot-example</artifactId>
   <name>Kogito Example :: PMML - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>kogito-springboot-examples</artifactId>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-springboot-examples</artifactId>

--- a/kogito-springboot-examples/process-business-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-business-rules-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>
@@ -14,8 +14,8 @@
   <description>Kogito business rules invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-business-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-business-rules-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <name>Kogito Example :: Process Business Rules Spring Boot</name>
@@ -14,8 +14,8 @@
   <description>Kogito business rules invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>
   <description>Process with DMN and DRL integration through REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-rest-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: REST :: Spring Boot</name>
   <description>Process with DMN and DRL integration through REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>
   <description>Process with DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-springboot/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-decisions-springboot</artifactId>
   <name>Kogito Example :: Process :: Decisions :: Spring Boot</name>
   <description>Process with DMN and DRL integration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Infinispan persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-infinispan-persistence-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Infinispan persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Kafka - Spring Boot, using multiple channels</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-multi-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Kafka - Spring Boot, using multiple channels</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Kafka - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-kafka-quickstart-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with Kafka - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>
@@ -15,8 +15,8 @@
 
   <properties>
     <enable.resource.mongodb>true</enable.resource.mongodb>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-mongodb-persistence-springboot</artifactId>
@@ -15,8 +15,8 @@
 
   <properties>
     <enable.resource.mongodb>true</enable.resource.mongodb>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-monitoring-springboot/Dockerfile
+++ b/kogito-springboot-examples/process-monitoring-springboot/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE springboot
 

--- a/kogito-springboot-examples/process-monitoring-springboot/pom.xml
+++ b/kogito-springboot-examples/process-monitoring-springboot/pom.xml
@@ -6,15 +6,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>
   <name>Kogito Example :: Process Monitoring :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-monitoring-springboot/pom.xml
+++ b/kogito-springboot-examples/process-monitoring-springboot/pom.xml
@@ -6,15 +6,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-monitoring-springboot</artifactId>
   <name>Kogito Example :: Process Monitoring :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-springboot-examples</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0.Final</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-springboot</artifactId>
@@ -15,8 +15,8 @@
 
     <properties>
         <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
-        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito.examples</groupId>
         <artifactId>kogito-springboot-examples</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.32.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>process-outbox-mongodb-springboot</artifactId>
@@ -15,8 +15,8 @@
 
     <properties>
         <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
-        <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/kogito-springboot-examples/process-performance-springboot/pom.xml
+++ b/kogito-springboot-examples/process-performance-springboot/pom.xml
@@ -7,15 +7,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>
   <description>Springboot Performance test</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-performance-springboot/pom.xml
+++ b/kogito-springboot-examples/process-performance-springboot/pom.xml
@@ -7,15 +7,15 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>process-performance-springboot</artifactId>
   <name>Kogito Example :: Springboot Performance test</name>
   <description>Springboot Performance test</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with PostgreSQL persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-postgresql-persistence-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito with PostgreSQL persistence - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation with REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-rest-service-call-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation with REST - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-scripts-springboot/pom.xml
+++ b/kogito-springboot-examples/process-scripts-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito script invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-scripts-springboot/pom.xml
+++ b/kogito-springboot-examples/process-scripts-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-scripts-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito script invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-service-calls-springboot/pom.xml
+++ b/kogito-springboot-examples/process-service-calls-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-service-calls-springboot/pom.xml
+++ b/kogito-springboot-examples/process-service-calls-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-service-calls-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito service invocation - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>
@@ -14,8 +14,8 @@
   <description>Order management service</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-springboot-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-springboot-example</artifactId>
@@ -14,8 +14,8 @@
   <description>Order management service</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-timer-springboot/pom.xml
+++ b/kogito-springboot-examples/process-timer-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>
@@ -12,8 +12,8 @@
   <description>Kogito with timers - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-timer-springboot/pom.xml
+++ b/kogito-springboot-examples/process-timer-springboot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-timer-springboot</artifactId>
@@ -12,8 +12,8 @@
   <description>Kogito with timers - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with custom life cycle - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-custom-lifecycle-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with custom life cycle - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot-with-console/docker-compose/docker-compose.yml
+++ b/kogito-springboot-examples/process-usertasks-springboot-with-console/docker-compose/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -87,7 +87,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - 8280:8080
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot-with-console</artifactId>
@@ -15,8 +15,8 @@
   
   <properties>
     <enable.resource.infinispan>true</enable.resource.infinispan>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot-with-console</artifactId>
@@ -15,8 +15,8 @@
   
   <properties>
     <enable.resource.infinispan>true</enable.resource.infinispan>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/docker-compose/docker-compose.yml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/docker-compose/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-infinispan:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-infinispan:1.32
     ports:
       - "8180:8080"
     depends_on:
@@ -87,7 +87,7 @@ services:
 
   management-console:
     container_name: management-console
-    image: quay.io/kiegroup/kogito-management-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-management-console:1.32
     ports:
       - 8280:8080
     depends_on:
@@ -103,7 +103,7 @@ services:
 
   task-console:
     container_name: task-console
-    image: quay.io/kiegroup/kogito-task-console:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-task-console:1.32
     ports:
       - 8380:8080
     depends_on:

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot-with-console</artifactId>
@@ -15,8 +15,8 @@
 
   <properties>
     <enable.resource.infinispan>true</enable.resource.infinispan>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot-with-console</artifactId>
@@ -15,8 +15,8 @@
 
   <properties>
     <enable.resource.infinispan>true</enable.resource.infinispan>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-oidc-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-usertasks-with-security-springboot</artifactId>
@@ -14,8 +14,8 @@
   <description>Kogito usertasks orchestration with security enabled on REST api - Spring Boot</description>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>rules-legacy-springboot-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>ruleunit-event-driven-springboot</artifactId>
   <name>Kogito Example :: RuleUnit Event Driven :: Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-springboot-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
   <artifactId>ruleunit-springboot-example</artifactId>
   <name>Kogito Example :: RuleUnit - Spring Boot</name>
 
   <properties>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <version.org.eclipse.jkube>1.4.0</version.org.eclipse.jkube>
     <!-- WebJars -->
     <version.org.webjars>4.5.3</version.org.webjars>
+    <version.maven>3.8.6</version.maven>
   </properties>
 
   <!-- distributionManagement section -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-no-bom-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -34,7 +34,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
 
     <surefire.forkCount>1</surefire.forkCount>
     <failsafe.include>**/*IT.java</failsafe.include>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-no-bom-parent</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <groupId>org.kie.kogito.examples</groupId>
@@ -34,7 +34,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
 
     <surefire.forkCount>1</surefire.forkCount>
     <failsafe.include>**/*IT.java</failsafe.include>

--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.32.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>serverless-workflow-examples</artifactId>

--- a/serverless-workflow-examples/pom.xml
+++ b/serverless-workflow-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>kogito-examples</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0.Final</version>
   </parent>
 
   <artifactId>serverless-workflow-examples</artifactId>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -18,7 +18,7 @@
         <version.org.assertj>3.22.0</version.org.assertj>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -18,7 +18,7 @@
         <version.org.assertj>3.22.0</version.org.assertj>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-event-service/src/main/resources/application.properties
@@ -11,5 +11,5 @@ quarkus.http.port=8181
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/docker-compose/docker-compose.yml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/docker-compose/docker-compose.yml
@@ -64,7 +64,7 @@ services:
 
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-postgresql:${KOGITO_VERSION}
+    image: quay.io/kiegroup/kogito-data-index-postgresql:1.32
     ports:
       - "8180:8080"
     depends_on:

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/main/resources/application.properties
@@ -48,5 +48,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
     <maven.compiler.release>11</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
     <maven.compiler.release>11</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/src/main/resources/application.properties
@@ -11,5 +11,5 @@ mp.messaging.incoming.move.path=/
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/main/resources/application.properties
@@ -81,5 +81,5 @@ quarkus.grpc.dev-mode.force-server-start=false
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -18,7 +18,7 @@
      <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-     <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+     <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
      <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
      <maven.compiler.release>11</maven.compiler.release>
      <version.org.slf4j>1.7.30</version.org.slf4j>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -18,7 +18,7 @@
      <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
      <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
      <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-     <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+     <kogito.bom.version>1.32.0.Final</kogito.bom.version>
      <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
      <maven.compiler.release>11</maven.compiler.release>
      <version.org.slf4j>1.7.30</version.org.slf4j>

--- a/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.devservices.enabled=false
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -16,11 +16,11 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
-    <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -16,11 +16,11 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>
-    <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+    <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
   </properties>
 
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/src/main/resources/application.properties
@@ -31,5 +31,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.devservices.enabled=false
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/main/resources/application.properties
@@ -32,5 +32,5 @@ org.kie.kogito.addons.knative.eventing.generate-kogito-source=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/src/main/resources/application.properties
@@ -15,5 +15,5 @@ quarkus.swagger-ui.always-include=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-services/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-services/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/src/main/resources/application.properties
@@ -11,5 +11,5 @@ quarkus.devservices.enabled=false
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/github-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/github-service/src/main/resources/application.properties
@@ -14,5 +14,5 @@ quarkus.native.enable-https-url-handler=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/notification-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/notification-service/src/main/resources/application.properties
@@ -11,5 +11,5 @@ quarkus.index-dependency.cloudevents.artifact-id=cloudevents-http-restful-ws
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/Dockerfile
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 
 ENV RUNTIME_TYPE quarkus
 

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/README.md
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/README.md
@@ -101,7 +101,7 @@ You should see a similar output like this:
 <details><summary>Build logs</summary>
 ```
 ---> Building and pushing image using tag quay.io/your_namespace/pr-checker-workflow:latest
-STEP 1: FROM quay.io/kiegroup/kogito-runtime-jvm:latest
+STEP 1: FROM quay.io/kiegroup/kogito-runtime-jvm:1.32
 STEP 2: ENV RUNTIME_TYPE quarkus
 STEP 3: COPY target/*-runner.jar $KOGITO_HOME/bin
 --> 58760d128d8

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pr-checker-workflow/src/main/resources/application.properties
@@ -23,6 +23,6 @@ mp.messaging.outgoing.checker_workflow_backend.url=${K_SINK}
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin
 

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/serverless-workflow-greeting-client-rpc-quarkus/src/main/resources/application.properties
@@ -16,5 +16,5 @@ quarkus.devservices.enabled=false
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -18,8 +18,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -18,8 +18,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-hello-world/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/kubernetes/jobs-service-postgresql.yml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/kubernetes/jobs-service-postgresql.yml
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
         - name: jobs-service-postgresql
-          image: quay.io/kiegroup/kogito-jobs-service-postgresql-nightly:latest
+          image: quay.io/kiegroup/kogito-jobs-service-postgresql-nightly:1.32
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/supporting-services.yml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/supporting-services.yml
@@ -157,7 +157,7 @@ spec:
     spec:
       containers:
         - name: jobs-service-postgresql
-          image: quay.io/kiegroup/kogito-jobs-service-postgresql-nightly:latest
+          image: quay.io/kiegroup/kogito-jobs-service-postgresql-nightly:1.32
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
@@ -25,6 +25,6 @@ mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin
 

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/src/main/resources/application.properties
@@ -23,5 +23,5 @@ quarkus.oidc.tenant-enabled=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/pom.xml
@@ -18,7 +18,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.failsafe.plugin>3.0.0-M7</version.failsafe.plugin>

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow/src/main/resources/application.properties
@@ -21,5 +21,5 @@ quarkus.oidc-client.acme_financial_oauth.credentials.client-secret.value=secret
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
     <maven.compiler.release>11</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
     <maven.compiler.release>11</maven.compiler.release>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
@@ -24,6 +24,6 @@ quarkus.swagger-ui.always-include=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin
 

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -18,8 +18,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -18,8 +18,8 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>1.32.0-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
+        <version.org.kie.kogito>1.32.0.Final</version.org.kie.kogito>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/main/resources/application.properties
@@ -13,5 +13,5 @@ quarkus.http.test-port=0
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.io.quarkiverse.reactivemessaging.http>1.0.1</version.io.quarkiverse.reactivemessaging.http>
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
   </properties>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.io.quarkiverse.reactivemessaging.http>1.0.1</version.io.quarkiverse.reactivemessaging.http>
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
   </properties>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/main/resources/application.properties
@@ -11,5 +11,5 @@ quarkus.swagger-ui.always-include=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.org.assertj>3.22.0</version.org.assertj>

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.org.assertj>3.22.0</version.org.assertj>

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/fake-stock-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/fake-stock-service/src/main/resources/application.properties
@@ -7,5 +7,5 @@ quarkus.http.port=8181
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/real-stock-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/real-stock-service/src/main/resources/application.properties
@@ -7,5 +7,5 @@ quarkus.http.port=8383
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/stock-portfolio-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/stock-portfolio-service/src/main/resources/application.properties
@@ -7,5 +7,5 @@ quarkus.http.port=8282
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.rest-client.stock_portfolio_svc_yaml.url=http://localhost:8282/
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/src/main/resources/application.properties
@@ -18,5 +18,5 @@ kogito.sw.operationIdStrategy=FULL_URI
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/src/main/resources/application.properties
@@ -18,5 +18,5 @@ kogito.sw.operationIdStrategy=FUNCTION_NAME
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/src/main/resources/application.properties
@@ -18,5 +18,5 @@ kogito.sw.operationIdStrategy=SPEC_TITLE
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <maven.compiler.release>11</maven.compiler.release>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
@@ -16,5 +16,5 @@ quarkus.rest-client.multiplication_yaml.url=http://localhost:8282
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.swagger-ui.always-include=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.swagger-ui.always-include=true
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+        <kogito.bom.version>1.32.0.Final</kogito.bom.version>
         <maven.compiler.release>11</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase/kubernetes/jobs-service-postgresql-knative.yml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase/kubernetes/jobs-service-postgresql-knative.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: jobs-service-postgresql
-          image: quay.io/kiegroup/kogito-jobs-service-allinone-nightly:latest
+          image: quay.io/kiegroup/kogito-jobs-service-allinone-nightly:1.32
           ports:
             - containerPort: 8080
               name: http1

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase/kubernetes/jobs-service-postgresql.yml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase/kubernetes/jobs-service-postgresql.yml
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
         - name: jobs-service-postgresql
-          image: quay.io/kiegroup/kogito-jobs-service-allinone-nightly:latest
+          image: quay.io/kiegroup/kogito-jobs-service-allinone-nightly:1.32
           ports:
             - containerPort: 8080
               name: http

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>2.0.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.32.0-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>1.32.0.Final</kogito.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase/src/main/resources/application.properties
@@ -23,5 +23,5 @@ mp.messaging.outgoing.response_events.method=POST
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:1.32
 %container.quarkus.jib.working-directory=/home/kogito/bin


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8417

The property version.enforcer.plugin is not set and defaults to Maven 3.8.6, the currently latest version. However, Maven wrapper is configured to use 3.8.4. The build fails due to this mismatch. 

The pull request explicitly configures both the enforcer plugin and and Maven wrapper to version 3.8.6.
