### PR TITLE
KOGITO-8534 Update default Maven to 3.8.7

### DIFF
--- a/.github/workflows/kogito-examples-pr.yml
+++ b/.github/workflows/kogito-examples-pr.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11]
-        maven-version: ['3.8.6']
+        maven-version: ['3.8.7']
         examples-subfolder:
           - kogito-quarkus-examples
           - kogito-springboot-examples


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8534

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/789
- https://github.com/kiegroup/drools/pull/4944
- https://github.com/kiegroup/kogito-runtimes/pull/2765
- https://github.com/kiegroup/kogito-apps/pull/1607
- https://github.com/kiegroup/kogito-examples/pull/1549