### PR TITLE
KOGITO-8971 kogito-springboot-examples - process-postgresql-persisten…

### DIFF
--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/src/test/java/org/acme/deals/DealsRestIT.java
@@ -54,7 +54,7 @@ public class DealsRestIT {
         // get task for john
         String taskId = given().accept(ContentType.JSON)
                 .when().get("/dealreviews/{uuid}/tasks?user=john", dealReviewId)
-                .then().log().ifValidationFails().statusCode(200).body("$.size", is(1)).extract().path("[0].id");
+                .then().log().ifValidationFails().statusCode(200).body("$.size()", is(1)).extract().path("[0].id");
 
         // complete review task
         given().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"review\" : \"very good work\"}")

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/src/test/java/org/acme/deals/DealsRestIT.java
@@ -70,7 +70,7 @@ public class DealsRestIT {
         // get task for john
         String taskId = given().accept(ContentType.JSON)
                 .when().get("/dealreviews/{uuid}/tasks?user=john", dealReviewId)
-                .then().log().ifValidationFails().statusCode(200).body("$.size", is(1)).extract().path("[0].id");
+                .then().log().ifValidationFails().statusCode(200).body("$.size()", is(1)).extract().path("[0].id");
 
         // complete review task
         given().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"review\" : \"very good work\"}")


### PR DESCRIPTION
…ce-springboot failing test

KOGITO-8971 kogito-springboot-examples - process-postgresql-persistence-springboot failing test fix

By default the process-postgresql-persistence-springboot test fails due to a small typo. It is trying to compare the size of the request result array, but it doesn't have the parenthesis after the size method name.
