### PR TITLE
KOGITO-9549 - Use fixed version for docker image version

### DIFF
--- a/kogito-springboot-examples/process-usertasks-springboot-with-console/docker-compose/docker-compose.yml
+++ b/kogito-springboot-examples/process-usertasks-springboot-with-console/docker-compose/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
   process-usertasks-springboot-with-console:
     container_name: process-usertasks-springboot-with-console
-    image: org.kie.kogito.examples/process-usertasks-springboot-with-console:${KOGITO_VERSION}
+    image: org.kie.kogito.examples/process-usertasks-springboot-with-console:1.0
     ports:
       - 8080:8080
     depends_on:

--- a/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot-with-console/pom.xml
@@ -133,10 +133,7 @@
             </executions>
             <configuration>
               <to>
-                <image>${project.groupId}/${project.artifactId}</image>
-                <tags>
-                  <tag>${project.version}</tag>
-                </tags>
+                <image>${project.groupId}/${project.artifactId}:1.0</image>
               </to>
             </configuration>
           </plugin>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/docker-compose/docker-compose.yml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/docker-compose/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
   process-usertasks-with-security-oidc-springboot-with-console:
     container_name: process-usertasks-with-security-oidc-springboot-with-console
-    image: org.kie.kogito.examples/process-usertasks-with-security-oidc-springboot-with-console:${KOGITO_VERSION}
+    image: org.kie.kogito.examples/process-usertasks-with-security-oidc-springboot-with-console:1.0
     ports:
       - 8080:8080
     depends_on:

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot-with-console/pom.xml
@@ -159,10 +159,7 @@
             </executions>
             <configuration>
               <to>
-                <image>${project.groupId}/${project.artifactId}</image>
-                <tags>
-                  <tag>${project.version}</tag>
-                </tags>
+                <image>${project.groupId}/${project.artifactId}:1.0</image>
               </to>
             </configuration>
           </plugin>


### PR DESCRIPTION
Align image version between Jib and Docker Compose, following the same pattern as other SpringBoot examples.