### PR TITLE
Adding schema/complex.json to native resources

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 quarkus.swagger-ui.always-include=true
 quarkus.native.native-image-xmx=8g
 quarkus.devservices.enabled=false
+quarkus.native.resources.includes=schema/complex.json
 
 # profile to pack this example into a container, to use it execute activate the maven container profile, -Dcontainer
 %container.quarkus.container-image.build=true


### PR DESCRIPTION
Till we found a better automatic way to do that we need to explicitly include the references resource in the native set
A more comprehesive solution will be done with https://issues.redhat.com/browse/KOGITO-9594, which will refactor the way external resources are loaded. 