### PR TITLE
KOGITO-9692 Fix release generation

### DIFF
--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -61,7 +61,7 @@ pipeline {
                         if (githubscm.isReleaseExist(getGitTag(), getGitAuthorCredsID())) {
                             githubscm.deleteRelease(getGitTag(), getGitAuthorCredsID())
                         }
-                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTag(getGitTag()), getGitAuthorCredsID())
+                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTagFromVersion(getGitTag()), getGitAuthorCredsID())
                         githubscm.updateReleaseBody(getGitTag(), getGitAuthorCredsID())
                     }
                 }


### PR DESCRIPTION
Depends on https://issues.redhat.com/browse/KOGITO-9692

Related:
- https://github.com/kiegroup/kogito-runtimes/pull/3170
- https://github.com/kiegroup/kogito-apps/pull/1826
- https://github.com/kiegroup/kogito-examples/pull/1761
- https://github.com/kiegroup/kogito-images/pull/1670
- https://github.com/kiegroup/kogito-operator/pull/1511
- https://github.com/kiegroup/kogito-serverless-operator/pull/225