### PR TITLE
PR multibranchPipelineJob

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -67,9 +67,7 @@ List getExamplesBuildMvnOptions(JenkinsFolder jobFolder) {
 }
 
 // PR checks
-// Deactivated due to ghprb not available on Apache Jenkins
-// TODO create PR job with branch source plugin
-// KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
+Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipelineJob(this, "${jenkins_path}/Jenkinsfile")
 
 // Init branch
 createSetupBranchJob()


### PR DESCRIPTION
Enabling a simplified PR check, which repeatedly (each 5 minutes) polls for new PRs coming from both the origin itself and forks.

Full ensemble:
kiegroup/kogito-runtimes#3224
kiegroup/kogito-apps#1879
kiegroup/kogito-examples#1808
kiegroup/drools#5523
kiegroup/kogito-images#1700
kiegroup/optaplanner-quickstarts#602
apache/incubator-kie-optaplanner#2975