### PR TITLE
kie-issues#587 abort stale builds

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     options {
         timestamps()
         timeout(time: 480, unit: 'MINUTES')
+        disableConcurrentBuilds(abortPrevious: true)
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-kogito-examples'


### PR DESCRIPTION
kiegroup/kie-issues#587

Aborting previous builds when new one is triggered (PR branch push or target branch push).

Full ensemble:
apache/incubator-kie-drools#5535
apache/incubator-kie-kogito-runtimes#3237
apache/incubator-kie-kogito-apps#1887
apache/incubator-kie-kogito-examples#1812
apache/incubator-kie-optaplanner#2988
apache/incubator-kie-optaplanner-quickstarts#608