### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -32,7 +32,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     checkout scm
                     examplesHelper = load '.ci/jenkins/helper_scripts/examples.groovy'
@@ -121,7 +121,11 @@ pipeline {
                         if (params.SKIP_TESTS) {
                             mvnCmd.skipTests() // Conflict somehow with Python testing. If `skipTests={anyvalue}` is set, then exec plugin is not executed ...
                         }
-                        mvnCmd.run('clean install')
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            mvnCmd
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                        }
                     }
                 }
             }
@@ -200,7 +204,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -312,7 +316,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
 
 MavenCommand getMavenCommand() {
     MavenCommand mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
-                                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                                 .withProperty('full')
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
@@ -333,20 +336,26 @@ void runMavenDeploy(boolean localDeployment = false) {
     }
 
     mvnCmd.withOptions(examplesHelper.getDeployableArtifactIds().collect { "-pl :${it} "})
-
-    mvnCmd.skipTests(true).run('clean deploy')
-
-    mvnCmd.skipTests(true).run('clean deploy')
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        mvnCmd
+            .skipTests(true)
+            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+            .run('clean deploy')
+    }
 }
 
 void runMavenStage() {
-    MavenStagingHelper stagingHelper = getStagingHelper()
-    deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
-    stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    MavenCommand mavenCommand = getMavenCommand()
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+        MavenStagingHelper stagingHelper = getStagingHelper(mavenCommand)
+        deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
+        stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    }
 }
 
-MavenStagingHelper getStagingHelper() {
-    return new MavenStagingHelper(this, getMavenCommand())
+MavenStagingHelper getStagingHelper(def mavenCommand) {
+    return new MavenStagingHelper(this, mavenCommand)
                 .withNexusReleaseUrl(env.NEXUS_RELEASE_URL)
                 .withNexusReleaseRepositoryId(env.NEXUS_RELEASE_REPOSITORY_ID)
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -93,11 +93,28 @@ pipeline {
                     dir(getRepoName()) {
                         def oldKogitoVersion = readMavenPom(file: 'pom.xml').version
                         echo "Got old Kogito version ${oldKogitoVersion}"
-
-                        maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(), getProjectVersion(), true)
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie.kogito', getProjectVersion())
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'kogito.bom.version', getProjectVersion())
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.drools', getDroolsVersion())
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            maven.mvnVersionsUpdateParentAndChildModules(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                getProjectVersion(),
+                                true
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'version.org.kie.kogito',
+                                getProjectVersion()
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'kogito.bom.version',
+                                getProjectVersion()
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'version.org.drools',
+                                getDroolsVersion()
+                            )
+                        }
 
                         if (getProjectVersion() != oldKogitoVersion) {
                             def status = sh(script: "grep -ir '${oldKogitoVersion}' --include='pom.xml'", returnStatus: true)
@@ -345,10 +362,8 @@ void runMavenDeploy(boolean localDeployment = false) {
 }
 
 void runMavenStage() {
-    MavenCommand mavenCommand = getMavenCommand()
     configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
-        mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE)
-        MavenStagingHelper stagingHelper = getStagingHelper(mavenCommand)
+        MavenStagingHelper stagingHelper = getStagingHelper(getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE))
         deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
         stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
     }

--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -23,7 +23,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -53,7 +53,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -27,7 +27,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     checkout scm
                     examplesHelper = load '.ci/jenkins/helper_scripts/examples.groovy'
@@ -77,7 +77,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
@@ -21,7 +21,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     sh 'printenv > env_props'
                     archiveArtifacts artifacts: 'env_props'
@@ -41,7 +41,12 @@ pipeline {
                         dir(project) {
                             githubscm.checkoutIfExists(project, changeAuthor, changeBranch, 'apache', changeTarget, true)
                             sh '.ci/environments/update.sh quarkus-3'
-                            getMavenCommand().withProperty('quickly').run('clean install')
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                getMavenCommand()
+                                    .withProperty('quickly')
+                                    .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                    .run('clean install')
+                            }
                         }
                     }
                 }
@@ -72,10 +77,8 @@ pipeline {
         }
     }
     post {
-        always {
-            script {
-                cleanWs()
-            }
+        cleanup {
+            cleanWs()
         }
         unsuccessful {
             script {
@@ -95,7 +98,6 @@ String getGitAuthorCredsId() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .withProperty('enforcer.skip')
 }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
@@ -59,7 +59,12 @@ pipeline {
                         dir(project) {
                             githubscm.checkoutIfExists(project, getGitAuthor(), getBuildBranch(), getBaseAuthor(), getBaseBranch(), true)
                             sh '.ci/environments/update.sh quarkus-3'
-                            getMavenCommand().withProperty('quickly').run('clean install')
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                getMavenCommand()
+                                    .withProperty('quickly')
+                                    .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                    .run('clean install')
+                            }
                         }
                     }
                 }
@@ -120,7 +125,7 @@ pipeline {
 
 void clean() {
     sh 'rm -rf ~/.rewrite-cache/'
-    util.cleanNode('docker')
+    util.cleanNode()
 }
 
 void sendErrorNotification() {
@@ -174,7 +179,6 @@ String getPRBranch() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .withProperty('enforcer.skip')
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -94,11 +94,28 @@ pipeline {
                     dir(getRepoName()) {
                         def oldKogitoVersion = readMavenPom(file: 'pom.xml').version
                         echo "Got old Kogito version ${oldKogitoVersion}"
-
-                        maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(), getKogitoVersion(), true)
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie.kogito', getKogitoVersion())
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'kogito.bom.version', getKogitoVersion())
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.drools', getDroolsVersion())
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            maven.mvnVersionsUpdateParentAndChildModules(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                getKogitoVersion(),
+                                true
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'version.org.kie.kogito',
+                                getKogitoVersion()
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'kogito.bom.version',
+                                getKogitoVersion()
+                            )
+                            maven.mvnSetVersionProperty(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                'version.org.drools',
+                                getDroolsVersion()
+                            )
+                        }
 
                         if (getKogitoVersion() != oldKogitoVersion) {
                             def status = sh(script: "grep -ir '${oldKogitoVersion}' --include='pom.xml'", returnStatus: true)

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -30,7 +30,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     checkout scm
                     examplesHelper = load '.ci/jenkins/helper_scripts/examples.groovy'
@@ -49,33 +49,42 @@ pipeline {
         stage('Build Drools') {
             steps {
                 script {
-                    getMavenCommand(droolsRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(droolsRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
         stage('Build Kogito Runtimes') {
             steps {
                 script {
-                    getMavenCommand(kogitoRuntimesRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(kogitoRuntimesRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
         stage('Build Kogito Apps') {
             steps {
                 script {
-                    getMavenCommand(kogitoAppsRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(kogitoAppsRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
@@ -138,7 +147,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -200,7 +209,6 @@ String getGitAuthorCredsID() {
 
 MavenCommand getMavenCommand(String directory = '') {
     def mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
     if (directory) {
         mvnCmd.inDirectory(directory)


### PR DESCRIPTION
apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273