### PR TITLE
NO-ISSUE: disable nexus deploy for examples

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -103,7 +103,7 @@ Closure setupAdditionalTimeoutForDefaultNightly = { script ->
 }
 
 Closure nightlyJobParamsGetter = isMainStream() ? JobParamsUtils.DEFAULT_PARAMS_GETTER : setup4AMCronTriggerJobParamsGetter
-KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true, setupAdditionalTimeoutForDefaultNightly)
+KogitoJobUtils.createNightlyBuildChainBuildAndTestJobForCurrentRepo(this, '', true, setupAdditionalTimeoutForDefaultNightly)
 setupSpecificBuildChainNightlyJob('native', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-main', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-branch', nightlyJobParamsGetter)


### PR DESCRIPTION
Switching from build-and-deploy to build-and-test default nightly job variant.