### PR TITLE
kie-issues#727: define push GH tokens for jenkins

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -77,7 +77,7 @@ pipeline {
                 script {
                     dir(getRepoName()) {
                         if (githubscm.isBranchExist('origin',getPRBranch())) {
-                            githubscm.removeRemoteBranch('origin', getPRBranch())
+                            githubscm.removeRemoteBranch('origin', getPRBranch(), getGitAuthorPushCredsId())
                         }
                         githubscm.createBranch(getPRBranch())
                     }
@@ -241,7 +241,7 @@ void saveReports() {
 
 void checkoutRepo() {
     deleteDir()
-    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsId()))
 }
 
 void addNotIgnoredPoms() {
@@ -272,8 +272,8 @@ void commitAndCreatePR() {
     // See: https://github.com/apache/incubator-kie-kogito-runtimes/pull/570#discussion_r449268738
     addNotIgnoredPoms()
     sh "git commit -m '${commitMsg}'"
-    githubscm.pushObject('origin', getPRBranch(), getGitAuthorCredsID())
-    deployProperties["${getRepoName()}.pr.link"] = githubscm.createPRWithLabels(commitMsg, prBody, getBuildBranch(), ['skip-ci'] as String[], getGitAuthorCredsID())
+    githubscm.pushObject('origin', getPRBranch(), getGitAuthorPushCredsId())
+    deployProperties["${getRepoName()}.pr.link"] = githubscm.createPRWithLabels(commitMsg, prBody, getBuildBranch(), ['skip-ci'] as String[], getGitAuthorCredsId())
 }
 
 boolean isSpecificArtifactsUpload() {
@@ -321,8 +321,12 @@ String getPRBranch() {
     return params.KOGITO_PR_BRANCH
 }
 
-String getGitAuthorCredsID() {
-    return env.AUTHOR_CREDS_ID
+String getGitAuthorCredsId() {
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 void setDeployPropertyIfNeeded(String key, def value) {

--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -91,8 +91,16 @@ String getGitAuthor() {
     return env.GIT_AUTHOR
 }
 
-String getGitAuthorCredsID() {
-    return env.AUTHOR_CREDS_ID
+String getGitAuthorCredsId() {
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
+}
+
+String getGitAuthorPushTokenCredsId() {
+    return env.GIT_AUTHOR_PUSH_TOKEN_CREDS_ID
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -101,13 +109,13 @@ String getGitAuthorCredsID() {
 
 void checkoutTag(String repo, String tagName, String localBranchName = tagName) {
     deleteDir()
-    checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
+    checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsId()))
     // Need to manually checkout branch since we are in 'detached HEAD' state after the git checkout command.
     sh "git checkout tags/${tagName} -b ${localBranchName}"
 }
 
 void setDefaultBranch(String defaultBranch) {
-    withCredentials([string(credentialsId: env.GITHUB_TOKEN_CREDS_ID, variable: 'GITHUB_TOKEN')]) {
+    withCredentials([string(credentialsId: getGitAuthorPushTokenCredsId(), variable: 'GITHUB_TOKEN')]) {
         // gh command from https://github.com/cli/cli/issues/929#issuecomment-629253585
         def newDefaultBranch = sh(script: "../gh api -XPATCH 'repos/${getGitAuthor()}/${getRepoName()}' -f default_branch=${defaultBranch} | jq '.default_branch'", returnStdout: true).trim()
         if (newDefaultBranch == "\"${defaultBranch}\"") {
@@ -120,7 +128,7 @@ void setDefaultBranch(String defaultBranch) {
 
 void forcePushProtectedBranch(String defaultBranch, String tempBranch) {
     setDefaultBranch(tempBranch)
-    withCredentials([usernamePassword(credentialsId: getGitAuthorCredsID(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+    withCredentials([usernamePassword(credentialsId: getGitAuthorPushCredsId(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
         sh """
         git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"
         git push --delete origin ${defaultBranch}

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -61,11 +61,11 @@ pipeline {
                 script {
                     dir(getRepoName()) {
                         checkoutRepo()
-                        if (githubscm.isReleaseExist(getGitTag(), getGitAuthorCredsID())) {
-                            githubscm.deleteRelease(getGitTag(), getGitAuthorCredsID())
+                        if (githubscm.isReleaseExist(getGitTag(), getGitAuthorCredsId())) {
+                            githubscm.deleteRelease(getGitTag(), getGitAuthorCredsId())
                         }
-                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTagFromVersion(getGitTag()), getGitAuthorCredsID())
-                        githubscm.updateReleaseBody(getGitTag(), getGitAuthorCredsID())
+                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTagFromVersion(getGitTag()), getGitAuthorCredsId())
+                        githubscm.updateReleaseBody(getGitTag(), getGitAuthorCredsId())
                     }
                 }
             }
@@ -154,8 +154,12 @@ String getGitAuthor() {
     return env.GIT_AUTHOR
 }
 
-String getGitAuthorCredsID() {
-    return env.AUTHOR_CREDS_ID
+String getGitAuthorCredsId() {
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 String getDeployPrLink() {
@@ -168,21 +172,21 @@ String getDeployPrLink() {
 
 void checkoutRepo() {
     deleteDir()
-    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsId()))
     // need to manually checkout branch since on a detached branch after checkout command
     sh "git checkout ${getBuildBranch()}"
 }
 
 void mergeAndPush(String prLink) {
     if (prLink) {
-        githubscm.mergePR(prLink, getGitAuthorCredsID())
-        githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
+        githubscm.mergePR(prLink, getGitAuthorCredsId())
+        githubscm.pushObject('origin', getBuildBranch(), getGitAuthorPushCredsId())
     }
 }
 
 void tagLatest() {
     if (getGitTag()) {
-        githubscm.tagLocalAndRemoteRepository('origin', getGitTag(), getGitAuthorCredsID(), env.BUILD_TAG, true)
+        githubscm.tagLocalAndRemoteRepository('origin', getGitTag(), getGitAuthorPushCredsId(), env.BUILD_TAG, true)
     }
 }
 

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
@@ -27,7 +27,7 @@ pipeline {
                     archiveArtifacts artifacts: 'env_props'
 
                     dir(getRepoName()) {
-                        checkout(githubscm.resolveRepository(getRepoName(), changeAuthor, changeBranch, false))
+                        checkout(githubscm.resolveRepository(getRepoName(), changeAuthor, changeBranch, false, getGitAuthorCredsId()))
                         // need to manually checkout branch since on a detached branch after checkout command
                         sh "git checkout ${changeBranch}"
                     }
@@ -70,7 +70,7 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        githubscm.pushObject('origin', changeBranch, getGitAuthorCredsId())
+                        githubscm.pushObject('origin', changeBranch, getGitAuthorPushCredsId())
                     }
                 }
             }
@@ -93,7 +93,11 @@ String getRepoName() {
 }
 
 String getGitAuthorCredsId() {
-    return env.AUTHOR_CREDS_ID
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 MavenCommand getMavenCommand() {

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
@@ -88,7 +88,7 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        githubscm.pushObject('origin', isPRSourceBranch() ? getBuildBranch() : getPRBranch(), getGitAuthorCredsId())
+                        githubscm.pushObject('origin', isPRSourceBranch() ? getBuildBranch() : getPRBranch(), getGitAuthorPushCredsId())
                     }
                 }
             }
@@ -139,7 +139,7 @@ void sendNotification(String body) {
 }
 
 void checkoutRepo(String repository, String branch) {
-    checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
+    checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false, getGitAuthorCredsId()))
     // need to manually checkout branch since on a detached branch after checkout command
     sh "git checkout ${branch}"
 }
@@ -170,7 +170,11 @@ boolean isPRSourceBranch() {
 }
 
 String getGitAuthorCredsId() {
-    return env.AUTHOR_CREDS_ID
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 String getPRBranch() {

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -149,7 +149,7 @@ pipeline {
                             def commitMsg = "Update version to Kogito ${getKogitoVersion()} / Drools ${getDroolsVersion()}"
 
                             githubscm.commitChanges(commitMsg)
-                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
+                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorPushCredsId())
                         } else {
                             println '[WARN] no changes to commit'
                         }
@@ -181,7 +181,7 @@ void sendNotification() {
 void checkoutRepo(String repository, String branch) {
     dir(repository) {
         deleteDir()
-        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
+        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false, getGitAuthorCredsId()))
         // need to manually checkout branch since on a detached branch after checkout command
         sh "git checkout ${branch}"
     }
@@ -220,8 +220,12 @@ String getDroolsVersion() {
     return params.DROOLS_VERSION
 }
 
-String getGitAuthorCredsID() {
-    return env.AUTHOR_CREDS_ID
+String getGitAuthorCredsId() {
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 MavenCommand getMavenCommand(String directory = '') {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -103,7 +103,7 @@ Closure setupAdditionalTimeoutForDefaultNightly = { script ->
 }
 
 Closure nightlyJobParamsGetter = isMainStream() ? JobParamsUtils.DEFAULT_PARAMS_GETTER : setup4AMCronTriggerJobParamsGetter
-KogitoJobUtils.createNightlyBuildChainBuildAndTestJobForCurrentRepo(this, '', true, setupAdditionalTimeoutForDefaultNightly)
+KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true, setupAdditionalTimeoutForDefaultNightly)
 setupSpecificBuildChainNightlyJob('native', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-main', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-branch', nightlyJobParamsGetter)
@@ -148,7 +148,8 @@ void createSetupBranchJob() {
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
 
@@ -178,8 +179,8 @@ void setupReleaseDeployJob() {
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
 
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
-        GITHUB_TOKEN_CREDS_ID: "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
@@ -220,8 +221,8 @@ void setupReleasePromoteJob() {
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
 
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
-        GITHUB_TOKEN_CREDS_ID: "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
@@ -253,8 +254,9 @@ void setupPostReleaseJob() {
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
-        GITHUB_TOKEN_CREDS_ID: "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_TOKEN_CREDS_ID: "${GIT_AUTHOR_PUSH_TOKEN_CREDENTIALS_ID}",
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -283,7 +285,8 @@ void setupPrQuarkus3RewriteJob() {
         commitContext: 'Quarkus 3 rewrite',
     ])
     jobParams.env.putAll([
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
     ])
     KogitoJobTemplate.createPRJob(this, jobParams)
@@ -294,7 +297,8 @@ void setupStandaloneQuarkus3RewriteJob() {
     jobParams.env.putAll(EnvUtils.getEnvironmentEnvVars(this, 'quarkus-3'))
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
-        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+        GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
         BASE_BRANCH: Utils.getGitBranch(this),
         BASE_AUTHOR: Utils.getGitAuthor(this),


### PR DESCRIPTION
apache/incubator-kie-issues#727

Introducing distinction of github credentials that have push privileges.

Previously all configured tokens had push rights, but after repository transfer that has been lost. We have a single robot account with push privilege, not to overuse it, and also to limit its usage only to where is necessary, I am introducing an additional configuration entry.

This change that bubbles through the DSL into Jenkinsfile pipelines using env variables.

PR ensemble:
apache/incubator-kie-kogito-pipelines#1128
apache/incubator-kie-drools#5597
apache/incubator-kie-optaplanner#3027
apache/incubator-kie-optaplanner-quickstarts#618
apache/incubator-kie-optaplanner-quickstarts#617
apache/incubator-kie-kogito-runtimes#3297
apache/incubator-kie-kogito-apps#1928
apache/incubator-kie-kogito-examples#1835
apache/incubator-kie-benchmarks#275