### PR TITLE
kie-issues#739: adjust repository after transfer to apache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ mvn_opts=
 mvn_cmd=mvn $(mvn_opts)
 
 build_chain_branch=$(shell git branch --show-current)
-build_chain_file='https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml'
-build_chain_group='kiegroup'
-build_chain_project='kiegroup/kogito-examples'
+build_chain_file='https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/.ci/pull-request-config.yaml'
+build_chain_group='apache'
+build_chain_project='apache/incubator-kie-kogito-examples'
 
 default: help
 
@@ -21,7 +21,7 @@ build-quickly:
 .PHONY: build-upstream
 ## (build-chain) Build upstream projects from the same branch. If needed, you can modify the `build_chain_file`, `build_chain_group` and `build_chain_branch`. See `build_chain_file` for setting correct environment variables
 build-upstream: build-chain
-	build-chain build cross_pr -f ${build_chain_file} -o /tmp/bc -p ${build_chain_project} -b ${build_chain_branch} -g ${build_chain_group} --skipParallelCheckout --skipProjectExecution kiegroup/kogito-examples --skipProjectCheckout kiegroup/kogito-examples
+	build-chain build cross_pr -f ${build_chain_file} -o /tmp/bc -p ${build_chain_project} -b ${build_chain_branch} -g ${build_chain_group} --skipParallelCheckout --skipProjectExecution apache/incubator-kie-kogito-examples --skipProjectCheckout apache/incubator-kie-kogito-examples
 
 .PHONY: build-pr
 pr_link=

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module contains a number of examples that you can take a look at and try ou
 Since Kogito aims at supporting both Quarkus and Spring Boot each example usually provides both type of projects.
 
 - Default branch is `stable`, pointing to the latest released version.
-- **[You can also check all versions by looking at releases.](https://github.com/kiegroup/kogito-examples/releases/latest)**
+- **[You can also check all versions by looking at releases.](https://github.com/apache/incubator-kie-kogito-examples/releases/latest)**
 
 ## Use alternative Quarkus platforms
 

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/operator/decisiontable-quarkus-example.yaml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/operator/decisiontable-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/decisiontable-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-quarkus-examples/dmn-listener-quarkus/operator/dmn-quarkus-example.yaml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/operator/dmn-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-listener-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/operator/dmn-pmml-quarkus-example.yaml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/operator/dmn-pmml-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-pmml-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-quarkus-examples/dmn-quarkus-example/operator/dmn-quarkus-example.yaml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/operator/dmn-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/README.md
@@ -134,7 +134,7 @@ Example response:
 
 ## Integration example with Trusty Service
 
-When the tracing addon is enabled, the tracing events are emitted and pushed to a Kafka broker. The [Trusty Service](https://github.com/kiegroup/kogito-apps/tree/main/trusty) can consume such events and store them on a storage. The Trusty Service exposes then some api to consume the information that has been collected. 
+When the tracing addon is enabled, the tracing events are emitted and pushed to a Kafka broker. The [Trusty Service](https://github.com/apache/incubator-kie-kogito-apps/tree/main/trusty) can consume such events and store them on a storage. The Trusty Service exposes then some api to consume the information that has been collected.
 A `docker-compose` example is provided in the current folder. In particular, when `docker-compose up` is run, a Kafka broker, an Infinispan container and the latest build of the trusty service configured to use Infinispan are deployed. 
 Once the services are up and running, after a decision has been evaluated, you can access the trusty service API to list the evaluations at `localhost:8081/executions` for example.
 

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/operator/dmn-quarkus-example.yaml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/operator/dmn-quarkus-example.yaml
@@ -36,7 +36,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-tracing-quarkus
-    uri: "https://github.com/kiegroup/kogito-examples/"
+    uri: "https://github.com/apache/incubator-kie-kogito-examples/"
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/flexible-process-quarkus/operator/flexible-process-quarkus.yaml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/operator/flexible-process-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/flexible-process-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/operator/travels.yaml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/operator/travels.yaml
@@ -45,7 +45,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/kogito-travel-agency/extended/travels
-    uri: "https://github.com/kiegroup/kogito-examples/"
+    uri: "https://github.com/apache/incubator-kie-kogito-examples/"
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/operator/visas.yaml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/operator/visas.yaml
@@ -25,7 +25,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/kogito-travel-agency/extended/visas
-    uri: "https://github.com/kiegroup/kogito-examples/"
+    uri: "https://github.com/apache/incubator-kie-kogito-examples/"
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
@@ -371,4 +371,4 @@ curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST h
 ### Querying the technical cache
 
 When running **Kogito Data Index Service** on dev mode, the GraphiQL UI is available at [http://localhost:8180](http://localhost:8180/) and allow to
-perform different queries on the model as is explained at [wiki/Data-Index-service](https://github.com/kiegroup/kogito-runtimes/wiki/Data-Index-Service)
+perform different queries on the model as is explained at [wiki/Data-Index-service](https://github.com/apache/incubator-kie-kogito-runtimes/wiki/Data-Index-Service)

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
@@ -227,4 +227,4 @@ EOF
 ### Querying the technical cache
 
 When running **Kogito Data Index Service** on dev mode, the GraphiQL UI is available at [http://localhost:8180](http://localhost:8180/) and allow to
-perform different queries on the model as is explained at [wiki/Data-Index-service](https://github.com/kiegroup/kogito-runtimes/wiki/Data-Index-Service)
+perform different queries on the model as is explained at [wiki/Data-Index-service](https://github.com/apache/incubator-kie-kogito-runtimes/wiki/Data-Index-Service)

--- a/kogito-quarkus-examples/ocp-tryout/applicationImage.md
+++ b/kogito-quarkus-examples/ocp-tryout/applicationImage.md
@@ -1,7 +1,7 @@
 ## Prepare Kogito application image
 
 The Tryout process installs a container image, which must be accessible from an image repository. If such an image exists, this step can be skipped.
-Below steps show the process of building and uploading an image using the example of the [extended Kogito Travel Agency](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels/) application:
+Below steps show the process of building and uploading an image using the example of the [extended Kogito Travel Agency](https://github.com/apache/incubator-kie-kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels/) application:
 - cd into `kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels`
 - build the application: `mvn clean package`
 - build the image: `docker build -f src/main/docker/Dockerfile.jvm -t quarkus/kogito-travel-agency-travels-jvm .`

--- a/kogito-quarkus-examples/pmml-quarkus-example/operator/pmml-quarkus-example.yaml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/operator/pmml-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/pmml-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-business-rules-quarkus/operator/process-business-rules-quarkus.yaml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/operator/process-business-rules-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-business-rules-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-error-handling/operator/process-scripts-quarkus.yaml
+++ b/kogito-quarkus-examples/process-error-handling/operator/process-scripts-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-error-handling
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/operator/process-infinispan-persistence-quarkus.yaml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/operator/process-infinispan-persistence-quarkus.yaml
@@ -35,7 +35,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/process-infinispan-persistence-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/operator/process-kafka-multi-quarkus.yaml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/operator/process-kafka-multi-quarkus.yaml
@@ -39,7 +39,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-kafka-multi-quickstart-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/operator/process-kafka-persistence-quarkus.yaml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/operator/process-kafka-persistence-quarkus.yaml
@@ -35,7 +35,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/process-kafka-persistence-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/operator/process-kafka-quickstart-quarkus.yaml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/operator/process-kafka-quickstart-quarkus.yaml
@@ -39,7 +39,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-kafka-quickstart-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/README.md
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 A quickstart project that deals with traveller processing carried by rules. It illustrates how easy it is to make the Kogito processes and rules to work with Knative Eventing. This project is based on
-the example [Process with Kafka](https://github.com/kiegroup/kogito-examples/tree/main/kogito-quarkus-examples/process-kafka-quickstart-quarkus).
+the example [Process with Kafka](https://github.com/apache/incubator-kie-kogito-examples/tree/main/kogito-quarkus-examples/process-kafka-quickstart-quarkus).
 
 This example shows
 

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/operator/process-mongodb-persistence-quarkus.yaml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/operator/process-mongodb-persistence-quarkus.yaml
@@ -35,7 +35,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/process-mongodb-persistence-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/README.md
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/README.md
@@ -36,7 +36,7 @@ curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : f
 
 <p align="center"><img src="docs/images/kafdrop_process_events_messages.png"></p>
 
-6. With the Kafka broker info from step 8, run the Kogito Data Index Service with MongoDB to consume Kafka messages: https://github.com/kiegroup/kogito-runtimes/wiki/Data-Index-Service
+6. With the Kafka broker info from step 8, run the Kogito Data Index Service with MongoDB to consume Kafka messages: https://github.com/apache/incubator-kie-kogito-runtimes/wiki/Data-Index-Service
 
 7. Shut down the cluster
 ```shell

--- a/kogito-quarkus-examples/process-quarkus-example/operator/process-quarkus-example.yaml
+++ b/kogito-quarkus-examples/process-quarkus-example/operator/process-quarkus-example.yaml
@@ -25,7 +25,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/process-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 #uncomment to enable persistence

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/operator/process-service-rest-call-quarkus.yaml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/operator/process-service-rest-call-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-service-rest-call-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/README.md
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This example contains a BPMN that performs two consecutive REST invocations using [RestWorkItemHandler](https://github.com/kiegroup/kogito-runtimes/blob/main/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java), an alternative declarative approach to service programatic calls. 
+This example contains a BPMN that performs two consecutive REST invocations using [RestWorkItemHandler](https://github.com/apache/incubator-kie-kogito-runtimes/blob/main/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java), an alternative declarative approach to service programatic calls.
 
 Note that in order to user a WorkItem in Kogito Editor, corresponding .wid file needs to located together with the bpmn file under the same directory
 

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/README.md
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/README.md
@@ -5,7 +5,7 @@
 A quickstart project that processes users in the system. It's main purpose is to to call external REST service
 to load a given user by its username.
 
-There are two ways to invoke a rest web service in Kogito: programmatically, as shown in this other [example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-service-calls-quarkus) or using RestWorkItemHandler, as in this example. 
+There are two ways to invoke a rest web service in Kogito: programmatically, as shown in this other [example](https://github.com/apache/incubator-kie-kogito-examples/tree/stable/kogito-quarkus-examples/process-service-calls-quarkus) or using RestWorkItemHandler, as in this example.
 
 Note that in order to user a WorkItem in Kogito Editor, corresponding .wid file needs to located together with the bpmn file under the same directory
 

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/operator/process-service-rest-call-quarkus.yaml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/operator/process-service-rest-call-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-service-rest-call-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-scripts-quarkus/operator/process-scripts-quarkus.yaml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/operator/process-scripts-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-scripts-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-service-calls-quarkus/operator/process-service-calls-quarkus.yaml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/operator/process-service-calls-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-service-calls-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-timer-quarkus/operator/process-timer-quarkus.yaml
+++ b/kogito-quarkus-examples/process-timer-quarkus/operator/process-timer-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-timer-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/operator/process-usertasks-lifecycle-quarkus.yaml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/operator/process-usertasks-lifecycle-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-usertasks-quarkus/operator/process-usertasks-quarkus.yaml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/operator/process-usertasks-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/operator/process-tasks-security-quarkus.yaml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/operator/process-tasks-security-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-with-security-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/operator/rules-quarkus-helloworld.yaml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/operator/rules-quarkus-helloworld.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/rules-quarkus-helloworld
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/operator/ruleunit-quarkus-example.yaml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/operator/ruleunit-quarkus-example.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/ruleunit-quarkus-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-quarkus-examples/trusty-demonstration/kubernetes/README.md
+++ b/kogito-quarkus-examples/trusty-demonstration/kubernetes/README.md
@@ -62,7 +62,7 @@ KOGITO_VERSION=v1.5.0
 
 Deploy the kogito operator in the cluster
 ```bash
-wget https://github.com/kiegroup/kogito-operator/releases/download/${KOGITO_VERSION}/kogito-operator.yaml
+wget https://github.com/apache/incubator-kie-kogito-operator/releases/download/${KOGITO_VERSION}/kogito-operator.yaml
 kubectl apply -f kogito-operator.yaml
 ```
 

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/README.md
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/README.md
@@ -21,7 +21,7 @@ You will need:
 mvn clean compile quarkus:dev
 ```
 
-The tracing addon emits tracing events to a Kafka broker running within Quarkus DevServices. A [Trusty Service](https://github.com/kiegroup/kogito-apps/tree/main/trusty) 
+The tracing addon emits tracing events to a Kafka broker running within Quarkus DevServices. A [Trusty Service](https://github.com/apache/incubator-kie-kogito-apps/tree/main/trusty)
 instance, also running within Quarkus DevServices, consumes the events and stores them in a PostgreSQL instance running 
 within Quarkus DevServices too. Within Quarkus DevMode the DevMode UI can be launched by pressing [d]  or navigating to
 http://localhost:8080/q/dev/.

--- a/kogito-springboot-examples/decisiontable-springboot-example/operator/decisiontable-springboot-example.yaml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/operator/decisiontable-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/decisiontable-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/dmn-listener-springboot/operator/dmn-springboot-example.yaml
+++ b/kogito-springboot-examples/dmn-listener-springboot/operator/dmn-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-listener-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/operator/dmn-pmml-springboot-example.yaml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/operator/dmn-pmml-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-pmml-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/dmn-springboot-example/operator/dmn-springboot-example.yaml
+++ b/kogito-springboot-examples/dmn-springboot-example/operator/dmn-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/dmn-tracing-springboot/README.md
+++ b/kogito-springboot-examples/dmn-tracing-springboot/README.md
@@ -108,6 +108,6 @@ Example response:
 
 ## Integration example with Trusty Service
 
-When the tracing addon is enabled, the tracing events are emitted and pushed to a Kafka broker. The [Trusty Service](https://github.com/kiegroup/kogito-apps/tree/main/trusty) can consume such events and store them on a storage. The Trusty Service exposes then some api to consume the information that has been collected. 
+When the tracing addon is enabled, the tracing events are emitted and pushed to a Kafka broker. The [Trusty Service](https://github.com/apache/incubator-kie-kogito-apps/tree/main/trusty) can consume such events and store them on a storage. The Trusty Service exposes then some api to consume the information that has been collected.
 A `docker-compose` example is provided in the current folder. In particular, when `docker-compose up` is run, a Kafka broker, an Infinispan container and the nightly build of the trusty service are deployed. 
 Once the services are up and running, after a decision has been evaluated, you can access the trusty service swagger at `localhost:8081/swagger-ui.html` and try to query what are the evaluations of the last day at `localhost:8081/v1/executions` for example.

--- a/kogito-springboot-examples/dmn-tracing-springboot/operator/dmn-tracing-springboot.yaml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/operator/dmn-tracing-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/dmn-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/flexible-process-springboot/operator/flexible-process-springboot.yaml
+++ b/kogito-springboot-examples/flexible-process-springboot/operator/flexible-process-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/flexible-process-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL: 
 ---

--- a/kogito-springboot-examples/pmml-springboot-example/operator/pmml-springboot-example.yaml
+++ b/kogito-springboot-examples/pmml-springboot-example/operator/pmml-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-springboot-examples/pmml-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-business-rules-springboot/operator/process-business-rules-springboot.yaml
+++ b/kogito-springboot-examples/process-business-rules-springboot/operator/process-business-rules-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-business-rules-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/operator/process-infinispan-persistence-springboot.yaml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/operator/process-infinispan-persistence-springboot.yaml
@@ -40,7 +40,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-infinispan-persistence-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-kafka-multi-springboot/operator/process-kafka-multi-springboot.yaml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/operator/process-kafka-multi-springboot.yaml
@@ -40,7 +40,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-kafka-multi-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/operator/process-kafka-quickstart-springboot.yaml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/operator/process-kafka-quickstart-springboot.yaml
@@ -40,7 +40,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-kafka-quickstart-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/operator/process-mongodb-persistence-springboot.yaml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/operator/process-mongodb-persistence-springboot.yaml
@@ -35,7 +35,7 @@ spec:
   type: RemoteSource
   gitSource:
     contextDir: kogito-quarkus-examples/process-mongodb-persistence-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/README.md
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/README.md
@@ -36,7 +36,7 @@ curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : f
 
 <p align="center"><img src="docs/images/kafdrop_process_events_messages.png"></p>
 
-6. With the Kafka broker info from step 8, run the Kogito Data Index Service with MongoDB to consume Kafka messages: https://github.com/kiegroup/kogito-runtimes/wiki/Data-Index-Service
+6. With the Kafka broker info from step 8, run the Kogito Data Index Service with MongoDB to consume Kafka messages: https://github.com/apache/incubator-kie-kogito-runtimes/wiki/Data-Index-Service
 
 7. Shut down the cluster
 ```shell

--- a/kogito-springboot-examples/process-rest-service-call-springboot/operator/process-service-rest-call-springboot.yaml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/operator/process-service-rest-call-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-service-rest-call-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-scripts-springboot/operator/process-scripts-springboot.yaml
+++ b/kogito-springboot-examples/process-scripts-springboot/operator/process-scripts-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-scripts-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-service-calls-springboot/operator/process-service-calls-springboot.yaml
+++ b/kogito-springboot-examples/process-service-calls-springboot/operator/process-service-calls-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-service-calls-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-springboot-example/operator/process-springboot-example.yaml
+++ b/kogito-springboot-examples/process-springboot-example/operator/process-springboot-example.yaml
@@ -41,7 +41,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-timer-springboot/operator/process-timer-springboot.yaml
+++ b/kogito-springboot-examples/process-timer-springboot/operator/process-timer-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-timer-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/operator/process-usertasks-lifecycle-springboot.yaml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/operator/process-usertasks-lifecycle-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-custom-lifecycle-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-usertasks-springboot/operator/process-usertasks-springboot.yaml
+++ b/kogito-springboot-examples/process-usertasks-springboot/operator/process-usertasks-springboot.yaml
@@ -31,7 +31,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/operator/process-tasks-security-springboot.yaml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/operator/process-tasks-security-springboot.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/process-usertasks-with-security-springboot
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/rules-legacy-springboot-example/operator/ruleunit-springboot-example.yaml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/operator/ruleunit-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/ruleunit-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/kogito-springboot-examples/ruleunit-springboot-example/operator/ruleunit-springboot-example.yaml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/operator/ruleunit-springboot-example.yaml
@@ -30,7 +30,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/ruleunit-springboot-example
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -76,14 +76,14 @@
   <!-- distributionManagement section -->
   <distributionManagement>
     <repository>
-      <id>jboss-releases-repository</id>
-      <name>JBoss Releases Repository</name>
-      <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+      <id>apache-release-staging-repository</id>
+      <name>Apache Release Staging Repository</name>
+      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
-      <id>jboss-snapshots-repository</id>
-      <name>JBoss Snapshot Repository</name>
-      <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+      <id>apache-snapshots-repository</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -91,9 +91,9 @@
     <!-- Bootstrap repository to locate the parent pom when the parent pom
       has not been build locally. -->
     <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <id>apache-public-repository-group</id>
+      <name>Apache Public Repository Group</name>
+      <url>https://repository.apache.org/content/groups/public/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>
@@ -108,17 +108,28 @@
 
   <pluginRepositories>
     <pluginRepository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the Apache Nexus one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the Apache Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use Apache Nexus repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>apache-public-repository-group</id>
+      <name>Apache Public Repository Group</name>
+      <url>https://repository.apache.org/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
       </releases>
       <snapshots>
         <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
       </snapshots>
     </pluginRepository>
   </pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,9 @@
   </pluginRepositories>
 
   <scm>
-    <connection>scm:git:https://github.com/kiegroup/kogito-examples.git</connection>
-    <developerConnection>scm:git:git@github.com:kiegroup/kogito-examples.git</developerConnection>
-    <url>https://github.com/kiegroup/kogito-examples</url>
+    <connection>scm:git:https://github.com/apache/incubator-kie-kogito-examples.git</connection>
+    <developerConnection>scm:git:git@github.com:apache/incubator-kie-kogito-examples.git</developerConnection>
+    <url>https://github.com/apache/incubator-kie-kogito-examples</url>
   </scm>
 
   <developers>

--- a/serverless-operator-examples/serverless-workflow-inventory/README.md
+++ b/serverless-operator-examples/serverless-workflow-inventory/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This example is meant to let you understand how to deploy on Kubernetes the [Inventory Logic Tutorial](https://redhat-scholars.github.io/serverless-workflow/osl/index.html) using the [Operator](https://github.com/kiegroup/kogito-serverless-operator).
+This example is meant to let you understand how to deploy on Kubernetes the [Inventory Logic Tutorial](https://redhat-scholars.github.io/serverless-workflow/osl/index.html) using the [Operator](https://github.com/apache/incubator-kie-kogito-serverless-operator).
 We'll report here for this reason only a short summary of the workflow use case, and we'd suggest you [read the complete documentation](https://redhat-scholars.github.io/serverless-workflow/osl/index.html) about this tutorial if you need more details about it.
 
 ### Use Case

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/operator/serverless-workflow-events-quarkus.yaml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/operator/serverless-workflow-events-quarkus.yaml
@@ -39,7 +39,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/serverless-workflow-events-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/serverless-workflow-greeting-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/README.md
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/README.md
@@ -43,12 +43,12 @@ You can follow the [Knative documentation](https://knative.dev/docs/install/serv
 4. **Knative** Serving and Eventing components installed. 
 We recommend [installing the Knative Operator](https://knative.dev/docs/install/knative-with-operators/) and install the rest of the components
 through it as described in their documentation.
-5. **Kogito Operator** installed in the namespace `kogito-github`. [Download the latest release](https://github.com/kiegroup/kogito-operator/releases), and run: `NAMESPACE=kogito-github ./hack/install.sh`.
+5. **Kogito Operator** installed in the namespace `kogito-github`. [Download the latest release](https://github.com/apache/incubator-kie-kogito-operator/releases), and run: `NAMESPACE=kogito-github ./hack/install.sh`.
 Alternatively, you can also install it via [OperatorHub](https://operatorhub.io/operator/kogito-operator).
 
 In your local machine you will need:
 
-1. To clone this repository and go to `serverless-workflow-github-showcase` directory (`git clone https://github.com/kiegroup/kogito-examples.git && cd serverless-workflow-github-showcase`)
+1. To clone this repository and go to `serverless-workflow-github-showcase` directory (`git clone https://github.com/apache/incubator-kie-kogito-examples.git && cd serverless-workflow-github-showcase`)
 2. [Java 11 SDK](https://openjdk.java.net/install/)
 3. [Maven 3.8.1+](https://maven.apache.org/install.html)
 4. [Podman](https://podman.io/getting-started/installation.html) or Docker to build the images

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/operator/serverless-workflow-greeting-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/serverless-workflow-greeting-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/serverless-workflow-examples/serverless-workflow-hello-world/README.md
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/README.md
@@ -1,1 +1,1 @@
-Serverless Workflow guide: https://github.com/kiegroup/kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+Serverless Workflow guide: https://github.com/apache/incubator-kie-kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/README.md
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/README.md
@@ -1,3 +1,3 @@
 # serverless-workflow-parallel-execution
 
-This project is the example application for the [https://github.com/kiegroup/kogito-docs/tree/main/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc](Working with parallelism) guide.
+This project is the example application for the [https://github.com/apache/incubator-kie-kogito-docs/tree/main/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc](Working with parallelism) guide.

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/operator/serverless-workflow-service-calls-quarkus.yaml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/operator/serverless-workflow-service-calls-quarkus.yaml
@@ -29,7 +29,7 @@ spec:
   #  value: "my value"
   gitSource:
     contextDir: kogito-quarkus-examples/serverless-workflow-service-calls-quarkus
-    uri: 'https://github.com/kiegroup/kogito-examples'
+    uri: 'https://github.com/apache/incubator-kie-kogito-examples'
   # set your maven nexus repository to speed up the build time
   #mavenMirrorURL:
 ---

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/README.md
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/README.md
@@ -1,1 +1,1 @@
-Serverless Workflow guide: https://github.com/kiegroup/kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/service-orchestration/configuring-openapi-services-endpoints.adoc
+Serverless Workflow guide: https://github.com/apache/incubator-kie-kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/service-orchestration/configuring-openapi-services-endpoints.adoc

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/README.md
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/README.md
@@ -1,1 +1,1 @@
-Serverless Workflow guide: https://github.com/kiegroup/kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc
+Serverless Workflow guide: https://github.com/apache/incubator-kie-kogito-docs/blob/main/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc


### PR DESCRIPTION
Fixes:
- apache/incubator-kie-issues#739

Adjusting URL references after repository transfer to apache.

Changes are limited to:
* pom.xml changes
* README.md URL references to migrated repositories
* operator yaml files references to migrated repositories

Especially the following were NOT addressed:
* XML namespaces within models or code snippets (e.g. an example response in README.md containing XML snippet with the namespace URI). apache/incubator-kie-examples#2237