### PR TITLE
[Fix_#3383] Setting metadata when using binary

### DIFF
--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/test/resources/application.properties
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/src/test/resources/application.properties
@@ -22,3 +22,5 @@ quarkus.log.level=INFO
 
 mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://0.0.0.0:8181
+
+kogito.addon.messaging.outgoing.cloudEventMode=structured

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/test/resources/application.properties
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/src/test/resources/application.properties
@@ -21,3 +21,5 @@ quarkus.http.test-port=8282
 quarkus.log.level=INFO
 
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://0.0.0.0:8181
+
+kogito.addon.messaging.outgoing.cloudEventMode=structured

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
@@ -34,6 +34,7 @@ quarkus.rest-client.subscription_service_yaml.url=${SUBSCRIPTION_SERVICE_URL:htt
 
 mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
 mp.messaging.incoming.kogito_incoming_stream.path=/
+kogito.addon.messaging.outgoing.cloudEventMode=structured
 
 # The K_SINK variable is automatically injected by the Knative ecosystem. The default value http://localhost:8181
 # is used for local testing, which correspond to the event-display local container.

--- a/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/src/main/resources/application.properties
@@ -21,6 +21,7 @@ quarkus.log.level=INFO
 
 # The K_SINK variable will be injected for us by the KogitoSource
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
+kogito.addon.messaging.outgoing.cloudEventMode.kogito_outgoing_stream=structured
 
 mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
 mp.messaging.incoming.kogito_incoming_stream.path=/


### PR DESCRIPTION
Since quarkus-http now uses binary as default the test condition for knative message has changed
Depends on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3386