### PR TITLE
Consolidate serverless workflow newsletter-subscription example

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/data-index-services.yml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/data-index-services.yml
@@ -88,16 +88,98 @@ spec:
               value: "http-events-support"
             - name: QUARKUS_HTTP_PORT
               value: "8080"
+            - name: KOGITO_SERVICE_URL
+              value: http://data-index-service-postgresql
 ---
 apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
-  name: data-index-service-postgresql-processes-trigger
+  name: data-index-service-postgresql-process-definition-trigger
 spec:
   broker: default
   filter:
     attributes:
-      type: ProcessInstanceEvent
+      type: ProcessDefinitionEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: data-index-service-postgresql
+    uri: /definitions
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: data-index-service-postgresql-process-error-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceErrorDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: data-index-service-postgresql
+    uri: /processes
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: data-index-service-postgresql-process-node-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceNodeDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: data-index-service-postgresql
+    uri: /processes
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: data-index-service-postgresql-process-sla-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceSLADataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: data-index-service-postgresql
+    uri: /processes
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: data-index-service-postgresql-process-state-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceStateDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: data-index-service-postgresql
+    uri: /processes
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: data-index-service-postgresql-process-variable-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceVariableDataEvent
   subscriber:
     ref:
       apiVersion: v1

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/supporting-services.yml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/kubernetes/supporting-services.yml
@@ -173,6 +173,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KOGITO_SERVICE_URL
+              value: http://jobs-service-postgresql
             - name: JOBS_SERVICE_PERSISTENCE
               value: "postgresql"
             - name: KOGITO_JOBS_SERVICE_HTTP_JOB_STATUS_CHANGE_EVENTS

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application-knative.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application-knative.properties
@@ -37,37 +37,19 @@ quarkus.datasource.password=${POSTGRES_PASSWORD:pass}
 
 # Events produced by kogito-addons-quarkus-jobs-knative-eventing to program the timers on the jobs service.
 mp.messaging.outgoing.kogito-job-service-job-request-events.connector=quarkus-http
-# The K_SINK variable is automatically injected by the Knative ecosystem. The default value http://localhost:8280
-# is used for local testing.
 mp.messaging.outgoing.kogito-job-service-job-request-events.url=${K_SINK:http://localhost:8280/v2/jobs/events}
 mp.messaging.outgoing.kogito-job-service-job-request-events.method=POST
 
-# process, variables and user tasks events configuration.
-mp.messaging.outgoing.kogito-processinstances-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-processinstances-events.url=${K_SINK:http://localhost:8180/processes}
-mp.messaging.outgoing.kogito-processinstances-events.method=POST
-
 kogito.events.usertasks.enabled=false
-mp.messaging.outgoing.kogito-usertaskinstances-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-usertaskinstances-events.url=${K_SINK:http://localhost:8180/tasks}
-mp.messaging.outgoing.kogito-usertaskinstances-events.method=POST
-
 kogito.events.variables.enabled=false
-mp.messaging.outgoing.kogito-variables-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-variables-events.url=${K_SINK:http://localhost:8180/variables}
-mp.messaging.outgoing.kogito-variables-events.method=POST
-
-mp.messaging.outgoing.kogito-processdefinitions-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-processdefinitions-events.url={K_SINK:http://localhost:8180/definitions}
-mp.messaging.outgoing.kogito-processdefinitions-events.method=POST
+kogito.addon.messaging.outgoing.cloudEventMode=structured
 
 ## Knative integration:
 
-# Use the Kogito service discovery mechanism to get the subscription-service url and set an env var with name SUBSCRIPTION_SERVICE_URL
+# Use the Kogito service discovery mechanism to get the subscription-service url
 # For more information see:
 # https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/cloud/kubernetes-service-discovery.html
-# https://quarkus.io/guides/deploying-to-kubernetes#environment-variables-from-keyvalue-pairs
-quarkus.knative.env.vars.subscription_service_url=${knative:services.v1.serving.knative.dev/newsletter-showcase/subscription-service}
+quarkus.rest-client.subscription_service_yaml.url=${knative:services.v1.serving.knative.dev/newsletter-showcase/subscription-service}
 
 # Configure current deployment to set an env var with name POSTGRES_HOST
 # For more information see: https://quarkus.io/guides/deploying-to-kubernetes#environment-variables-from-keyvalue-pairs
@@ -84,7 +66,9 @@ quarkus.knative.env.vars.postgres_host=newsletter-postgres
 # you can change this property with -Pknative -Dquarkus.container-image.group from the command line.
 quarkus.container-image.group=dev.local
 quarkus.kubernetes.deployment-target=knative
+# The name of the application. This value will be used for naming Kubernetes resources like: Deployment, Service,  etc.
 quarkus.knative.name=subscription-flow
+quarkus.container-image.name=${quarkus.knative.name}
 quarkus.knative.image-pull-policy=IfNotPresent
 
 # Kogito Knative integration

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/main/resources/application.properties
@@ -30,7 +30,7 @@ quarkus.log.category."org.kie.kogito.addon.quarkus.messaging".level=DEBUG
 # Internally, Kogito Serverless Workflow uses the Quarkus OpenAPI Generator extension.
 # The default value http://localhost:8282 is used for local testing. In kubernetes environments, the env var
 # SUBSCRIPTION_SERVICE_URL will be used instead. This env var is configured in the application-knative.properties file.
-quarkus.rest-client.subscription_service_yaml.url=${SUBSCRIPTION_SERVICE_URL:http://localhost:8282}
+quarkus.rest-client.subscription_service_yaml.url=http://localhost:8282
 
 mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
 mp.messaging.incoming.kogito_incoming_stream.path=/
@@ -48,22 +48,6 @@ mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK:http://localhost:8181}
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 
-# process, variables and user tasks events configuration.
-mp.messaging.outgoing.kogito-processinstances-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-processinstances-events.url=http://localhost:8180/processes
-mp.messaging.outgoing.kogito-processinstances-events.method=POST
-
 kogito.events.usertasks.enabled=false
-mp.messaging.outgoing.kogito-usertaskinstances-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-usertaskinstances-events.url=http://localhost:8180/tasks
-mp.messaging.outgoing.kogito-usertaskinstances-events.method=POST
-
 kogito.events.variables.enabled=false
-mp.messaging.outgoing.kogito-variables-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-variables-events.url=http://localhost:8180/variables
-mp.messaging.outgoing.kogito-variables-events.method=POST
 
-# process definitions events configuration.
-mp.messaging.outgoing.kogito-processdefinitions-events.connector=quarkus-http
-mp.messaging.outgoing.kogito-processdefinitions-events.url=http://localhost:8180/definitions
-mp.messaging.outgoing.kogito-processdefinitions-events.method=POST


### PR DESCRIPTION
closes #1869  


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-examples] quarkus-lts</b>
 
- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch 
  Please add comment: <b>Jenkins (re)run [kogito-examples] native-lts</b>
 
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
