### PR TITLE
Modified pgAdmin log level to reduce noise in the log output (Issue id: #1080)

### DIFF
--- a/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/docker-compose/docker-compose.yml
+++ b/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/docker-compose/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: pass
       PGADMIN_CONFIG_SERVER_MODE: 'False'
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
+      GUNICORN_ACCESS_LOGFILE: '/dev/null'
 
   data-index:
     container_name: data-index


### PR DESCRIPTION
 The goal is reduce the noise of the logs generated by pgAdmin. The logs were being flooded with access log entries, unnecessary for our operations.

**Changes**:

- Set the **GUNICORN_ACCESS_LOGFILE** to **'/dev/null'** under pgAdmin env. in the docker-compose.yml. This prevents logs being written to the console. 

- Tested the applied changes and the console was not flooded with log entries

- Improves **log clarity** and performance

- This change may prevent us diagnosing issues related to HTTP errors

**Issue** <https://github.com/apache/incubator-kie-issues/issues/1080>


