### PR TITLE
Alternative config in process-usertasks-timer-data-index-persistence-addon-quarkus docker compose to avoid using  kubernetes.docker.internal (Issue id:#1083)

### DIFF
--- a/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/README.md
@@ -189,6 +189,11 @@ mvn clean package -Pcontainer
 ```
 This will build the example quarkus application and create a Docker image that will be started in the `docker-compose` template.
 
+To ensure compatibility across different environments, including those not utilizing docker desktop, there is need to use different host address
+> macOS/Windows: Use 'host.docker.internal' as it is configured by docker to point to the host machine.
+>Linux: Use 172.17.0.1 which is default gateway for docker on linux systems.
+These settings are integrated into startServices.sh to adjust the .env file used by docker-compose.
+
 To execute the full example (including consoles), open a Terminal and run the following command inside the `docker-compose` folder:
 
 ```shell

--- a/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/docker-compose/startServices.sh
+++ b/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/docker-compose/startServices.sh
@@ -33,7 +33,7 @@ echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
 echo "COMPOSE_PROFILES='${PROFILE}'" >> ".env"
 
 if [ "$(uname)" == "Darwin" ]; then
-   echo "DOCKER_GATEWAY_HOST=kubernetes.docker.internal" >> ".env"
+   echo "DOCKER_GATEWAY_HOST=host.docker.internal" >> ".env"
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
    echo "DOCKER_GATEWAY_HOST=172.17.0.1" >> ".env"
 fi


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1083

Considering previous kubernetes.docker.internal config specific to docker desktop, modified **startServices.sh** script to detect the operating system and adjust the **DOCKER_GATEWAY_HOST**

- **Linux** uses **172.17.0.1**
- **macOS/Windows** uses **host.docker.internal**

Further updated **README.md** to include instructions on docker gateway host setting.

**Issue** <https://github.com/apache/incubator-kie-issues/issues/1083>