### PR TITLE
Removed kogito-runtime-jvm-nightly:latest in order to build example container (Issue: #1081)

### DIFF
--- a/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/process-usertasks-timer-data-index-persistence-addon-quarkus/src/main/resources/application.properties
@@ -40,9 +40,6 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.group=${USER}
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
-%container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm-nightly:latest
-%container.quarkus.jib.working-directory=/home/kogito/bin
 %container.quarkus.container-image.name=kogito-example-service
 
 %dev.quarkus.kogito.devservices.enabled=true


### PR DESCRIPTION
The previous configuration was using Jib with nightly:latest version, simplified container configuration in application.properties for 'kogito-example-service' by removing below Jib configuration.

%container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm-nightly:latest
%container.quarkus.jib.working-directory=/home/kogito/bin

-  Potential sources of errors associated with base image update and script paths can be reduced, increases flexibility of build process.

- Tested the example to verify that it functions as expected without the removed Jib config.

Issue <https://github.com/apache/incubator-kie-issues/issues/1081>