### PR TITLE
kie-issues#776: automate PR merge into protected branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -49,8 +49,8 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
+                        approveAndMergePR(getDeployPrLink())
                         checkoutRepo()
-                        mergeAndPush(getDeployPrLink())
                         tagLatest()
                     }
                 }
@@ -63,10 +63,10 @@ pipeline {
                     dir(getRepoName()) {
                         checkoutRepo()
                         if (githubscm.isReleaseExist(getGitTag(), getGitAuthorCredsId())) {
-                            githubscm.deleteRelease(getGitTag(), getGitAuthorCredsId())
+                            githubscm.deleteRelease(getGitTag(), getGitAuthorPushCredsId())
                         }
-                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTagFromVersion(getGitTag()), getGitAuthorCredsId())
-                        githubscm.updateReleaseBody(getGitTag(), getGitAuthorCredsId())
+                        githubscm.createReleaseWithGeneratedReleaseNotes(getGitTag(), getBuildBranch(), githubscm.getPreviousTagFromVersion(getGitTag()), getGitAuthorPushCredsId())
+                        githubscm.updateReleaseBody(getGitTag(), getGitAuthorPushCredsId())
                     }
                 }
             }
@@ -178,10 +178,10 @@ void checkoutRepo() {
     sh "git checkout ${getBuildBranch()}"
 }
 
-void mergeAndPush(String prLink) {
-    if (prLink) {
-        githubscm.mergePR(prLink, getGitAuthorCredsId())
-        githubscm.pushObject('origin', getBuildBranch(), getGitAuthorPushCredsId())
+void approveAndMergePR(String prLink) {
+    if (prLink?.trim()) {
+        githubscm.approvePR(prLink, getGitAuthorPushCredsId())
+        githubscm.mergePR(prLink, getGitAuthorPushCredsId())
     }
 }
 


### PR DESCRIPTION
Part of:
* apache/incubator-kie-issues#776

Other related PRs:
* apache/incubator-kie-kogito-pipelines#1194
* apache/incubator-kie-benchmarks#286
* apache/incubator-kie-docs#4536
* apache/incubator-kie-kogito-runtimes#3501
* apache/incubator-kie-kogito-apps#2047
* apache/incubator-kie-kogito-examples#1914
* apache/incubator-kie-kogito-docs#626
* apache/incubator-kie-drools#5927
* apache/incubator-kie-optaplanner#3083
* apache/incubator-kie-kogito-serverless-operator#462

Replacing old approach to merge PRs:  merge locally + push into remote

New behavior relies on gh cli directly to approve and merge PR.