### PR TITLE
kie-issues#1123: add snapshots repository to resolve parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,18 @@
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
   </properties>
 
+  <repositories>
+    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/snapshots</url>
+    </repository>
+  </repositories>
+
   <profiles>
     <profile>
       <id>default</id>


### PR DESCRIPTION
Adjustment for
* apache/incubator-kie-issues#1123

When a project relies on snapshot parent, it needs to define (at least) snapshot repositories to get the parent from. Otherwise a settings.xml repository entry would be needed to get users going.

the other case, kogito-apps have been already addressed as part of
* apache/incubator-kie-kogito-apps#2049