### PR TITLE
[incubator-kie-issues#1249] Fix REST call in process-rest-workitem-quarkus example

### DIFF
--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -81,10 +81,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/java/org/acme/travels/rest/UserResource.java
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/java/org/acme/travels/rest/UserResource.java
@@ -19,19 +19,23 @@
 package org.acme.travels.rest;
 
 import org.acme.travels.User;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 
 @Path("/v2")
-@RegisterRestClient
-public interface UsersRemoteService {
+public class UserResource {
+
+    @Inject
+    UserService userService;
 
     @GET
     @Path("/user/{username}")
     @Produces("application/json")
-    User get(@PathParam("username") String username);
+    public User getUser(@PathParam("username") String username) {
+        return userService.getUser(username);
+    }
 }

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/java/org/acme/travels/rest/UserService.java
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/java/org/acme/travels/rest/UserService.java
@@ -1,0 +1,18 @@
+package org.acme.travels.rest;
+
+import org.acme.travels.User;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class UserService {
+
+    public User getUser(String name) {
+        if ("test".equals(name)) {
+            User user = new User();
+            user.setLastName(name);
+            return user;
+        }
+        return null;
+    }
+}

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/resources/application.properties
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/resources/application.properties
@@ -21,6 +21,3 @@
 # quarkus.package.type=fast-jar
 
 quarkus.swagger-ui.always-include=true
-
-org.acme.travels.rest.UsersRemoteService/mp-rest/url=https://petstore.swagger.io
-org.acme.travels.rest.UsersRemoteService/mp-rest/scope=javax.enterprise.context.ApplicationScoped

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/resources/org/acme/travels/users.bpmn
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/src/main/resources/org/acme/travels/users.bpmn
@@ -1,13 +1,25 @@
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_1ztzQLGyEDmz-aPY8v7uEg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_yBVmwPqbEDyfjZKSxf4Vqg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_travellerItem" structureRef="org.acme.travels.User"/>
   <bpmn2:itemDefinition id="_usernameItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_E5D17755-D671-43ED-BD7D-F6538933069C_InMessageType"/>
+  <bpmn2:itemDefinition id="_E5D17755-D671-43ED-BD7D-F6538933069C_OutMessageType"/>
   <bpmn2:itemDefinition id="__E5D17755-D671-43ED-BD7D-F6538933069C_ParameterInputXItem" structureRef="org.acme.travels.User"/>
-  <bpmn2:itemDefinition id="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_usernameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_ResultOutputXItem" structureRef="java.lang.Object"/>
+  <bpmn2:message id="_E5D17755-D671-43ED-BD7D-F6538933069C_InMessage" itemRef="_E5D17755-D671-43ED-BD7D-F6538933069C_InMessageType"/>
+  <bpmn2:message id="_E5D17755-D671-43ED-BD7D-F6538933069C_OutMessage" itemRef="_E5D17755-D671-43ED-BD7D-F6538933069C_OutMessageType"/>
   <bpmn2:interface id="_E5D17755-D671-43ED-BD7D-F6538933069C_ServiceInterface" name="org.acme.travels.services.AuditService" implementationRef="org.acme.travels.services.AuditService">
-    <bpmn2:operation id="_E5D17755-D671-43ED-BD7D-F6538933069C_ServiceOperation" name="auditUser" implementationRef="auditUser"/>
+    <bpmn2:operation id="_E5D17755-D671-43ED-BD7D-F6538933069C_ServiceOperation" name="auditUser" implementationRef="auditUser">
+      <bpmn2:inMessageRef>_E5D17755-D671-43ED-BD7D-F6538933069C_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_E5D17755-D671-43ED-BD7D-F6538933069C_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
   </bpmn2:interface>
+  <bpmn2:collaboration id="_C2F952AF-07EA-4F70-8DE1-3A50D544E83A" name="Default Collaboration">
+    <bpmn2:participant id="_566F32DE-B61E-4CBA-A56A-6F05C1FEB0B6" name="Pool Participant" processRef="users"/>
+  </bpmn2:collaboration>
   <bpmn2:process id="users" drools:packageName="org.acme.travels" drools:version="1.0" drools:adHoc="false" name="users" isExecutable="true" processType="Public">
     <bpmn2:property id="traveller" itemSubjectRef="_travellerItem" name="traveller"/>
     <bpmn2:property id="username" itemSubjectRef="_usernameItem" name="username"/>
@@ -21,14 +33,6 @@
         </drools:metaData>
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
-    <bpmn2:sequenceFlow id="_4EFC11AE-52BB-4EEF-B241-CFAAE4B7AE93" name="Yes" sourceRef="_13BAF867-3CA8-4C6F-85C6-D3FD748D07D2" targetRef="_E5D17755-D671-43ED-BD7D-F6538933069C">
-      <bpmn2:extensionElements>
-        <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[Yes]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return traveller != null;]]></bpmn2:conditionExpression>
-    </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_BF17E37C-6984-4F27-9B6A-A9880E95B019" name="No" sourceRef="_13BAF867-3CA8-4C6F-85C6-D3FD748D07D2" targetRef="_95885F94-555D-485A-BB86-5E835B9C3389">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
@@ -36,6 +40,14 @@
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return traveller == null;]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_4EFC11AE-52BB-4EEF-B241-CFAAE4B7AE93" name="Yes" sourceRef="_13BAF867-3CA8-4C6F-85C6-D3FD748D07D2" targetRef="_E5D17755-D671-43ED-BD7D-F6538933069C">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Yes]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return traveller != null;]]></bpmn2:conditionExpression>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_1A98DE32-CF81-424B-A59E-6D22899E31C0" sourceRef="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8" targetRef="_13BAF867-3CA8-4C6F-85C6-D3FD748D07D2"/>
     <bpmn2:sequenceFlow id="_4EB288EA-3135-4B97-BB46-E77159F78832" sourceRef="_E5D17755-D671-43ED-BD7D-F6538933069C" targetRef="_FD4D7A19-558E-4347-8CFE-376792FEDA57">
@@ -57,13 +69,15 @@
       <bpmn2:incoming>_DBA10C00-6407-4EF5-9D85-01177AE8F39F</bpmn2:incoming>
       <bpmn2:outgoing>_1A98DE32-CF81-424B-A59E-6D22899E31C0</bpmn2:outgoing>
       <bpmn2:ioSpecification>
-        <bpmn2:dataInput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputX" drools:dtype="String" itemSubjectRef="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputXItem" name="Url"/>
+        <bpmn2:dataInput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputX" drools:dtype="String" itemSubjectRef="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputXItem" name="Url"/>
         <bpmn2:dataInput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_usernameInputX" drools:dtype="String" itemSubjectRef="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_usernameInputXItem" name="username"/>
+        <bpmn2:dataInput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputX" drools:dtype="String" itemSubjectRef="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputXItem" name="Port"/>
         <bpmn2:dataInput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_TaskNameInputX" drools:dtype="Object" name="TaskName"/>
         <bpmn2:dataOutput id="_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_ResultOutputX" drools:dtype="java.lang.Object" itemSubjectRef="__296CCA4D-3C70-469C-A10E-2FF421D4D7A8_ResultOutputXItem" name="Result"/>
         <bpmn2:inputSet>
-          <bpmn2:dataInputRefs>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_usernameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_TaskNameInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
         <bpmn2:outputSet>
@@ -71,15 +85,22 @@
         </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputX</bpmn2:targetRef>
+        <bpmn2:targetRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputX</bpmn2:targetRef>
         <bpmn2:assignment>
           <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[/v2/user/{username}]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_EndpointInputX]]></bpmn2:to>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_UrlInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>username</bpmn2:sourceRef>
         <bpmn2:targetRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_usernameInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[8080]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_PortInputX]]></bpmn2:to>
+        </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_TaskNameInputX</bpmn2:targetRef>
@@ -88,6 +109,10 @@
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_TaskNameInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_296CCA4D-3C70-469C-A10E-2FF421D4D7A8_ResultOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>traveller</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
     </bpmn2:task>
     <bpmn2:startEvent id="_5A1A031B-CA99-4CB7-BC07-A730CE95D655" name="StartProcess">
       <bpmn2:extensionElements>
@@ -131,8 +156,8 @@
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:incoming>_1A98DE32-CF81-424B-A59E-6D22899E31C0</bpmn2:incoming>
-      <bpmn2:outgoing>_BF17E37C-6984-4F27-9B6A-A9880E95B019</bpmn2:outgoing>
       <bpmn2:outgoing>_4EFC11AE-52BB-4EEF-B241-CFAAE4B7AE93</bpmn2:outgoing>
+      <bpmn2:outgoing>_BF17E37C-6984-4F27-9B6A-A9880E95B019</bpmn2:outgoing>
     </bpmn2:exclusiveGateway>
     <bpmn2:endEvent id="_FD4D7A19-558E-4347-8CFE-376792FEDA57" name="Done">
       <bpmn2:extensionElements>
@@ -171,14 +196,14 @@
         <di:waypoint x="612" y="189"/>
         <di:waypoint x="774" y="189"/>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__13BAF867-3CA8-4C6F-85C6-D3FD748D07D2_to_shape__E5D17755-D671-43ED-BD7D-F6538933069C" bpmnElement="_4EFC11AE-52BB-4EEF-B241-CFAAE4B7AE93">
+        <di:waypoint x="830" y="189"/>
+        <di:waypoint x="910" y="189"/>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__13BAF867-3CA8-4C6F-85C6-D3FD748D07D2_to_shape__95885F94-555D-485A-BB86-5E835B9C3389" bpmnElement="_BF17E37C-6984-4F27-9B6A-A9880E95B019">
         <di:waypoint x="802" y="217"/>
         <di:waypoint x="802" y="325"/>
         <di:waypoint x="1144" y="325"/>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__13BAF867-3CA8-4C6F-85C6-D3FD748D07D2_to_shape__E5D17755-D671-43ED-BD7D-F6538933069C" bpmnElement="_4EFC11AE-52BB-4EEF-B241-CFAAE4B7AE93">
-        <di:waypoint x="830" y="189"/>
-        <di:waypoint x="910" y="189"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__5A1A031B-CA99-4CB7-BC07-A730CE95D655_to_shape__296CCA4D-3C70-469C-A10E-2FF421D4D7A8" bpmnElement="_DBA10C00-6407-4EF5-9D85-01177AE8F39F">
         <di:waypoint x="460" y="189"/>
@@ -241,7 +266,7 @@
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_1ztzQLGyEDmz-aPY8v7uEg</bpmn2:source>
-    <bpmn2:target>_1ztzQLGyEDmz-aPY8v7uEg</bpmn2:target>
+    <bpmn2:source>_yBVmwPqbEDyfjZKSxf4Vqg</bpmn2:source>
+    <bpmn2:target>_yBVmwPqbEDyfjZKSxf4Vqg</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1249

Some points regarding the changes to fix this example:
* Port needed to change from 80 to 8080 (added parameter in the WIH of the process)
* The previous version of the example used Quarkus REST Client, this would have required a config change
* With the REST client approach, the REST call was targeting `https://petstore.swagger.io/v2/user/{user}`. This call might have returned 200 for a demo user in the past, but now always returns 404. This makes it unusable for the example.
* To simplify the example, I replaced the usage of the REST Client using petstore with a simple REST service within the application.