### PR TITLE
[disabling_tracing-decision_module] Removing tracing-decision module from maven reactor

### DIFF
--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -61,7 +61,6 @@
         <module>dmn-quarkus-example</module>
         <module>dmn-resource-jar-quarkus-example</module>
         <module>dmn-multiple-models-quarkus-example</module>
-        <module>dmn-tracing-quarkus</module>
         <module>flexible-process-quarkus</module>
         <module>kogito-travel-agency</module>
         <module>onboarding-example</module>
@@ -106,7 +105,6 @@
         <module>rules-quarkus-helloworld</module>
         <module>ruleunit-event-driven-quarkus</module>
         <module>ruleunit-quarkus-example</module>
-        <module>trusty-tracing-quarkus-devservices</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
This is a follow-up on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3531. More information in the kogito-runtimes PR.

kogito-runtimes PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3533
kogito-apps PR: https://github.com/apache/incubator-kie-kogito-apps/pull/2065