### PR TITLE
NO-ISSUE: Update all scesim file paths to relative paths

### DIFF
--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/src/test/resources/TrafficViolationTest.scesim
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/src/test/resources/TrafficViolationTest.scesim
@@ -753,7 +753,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/Traffic Violation.dmn</dmnFilePath>
+    <dmnFilePath>../../main/resources/Traffic Violation.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF</dmnNamespace>
     <dmnName>Traffic Violation</dmnName>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/src/test/resources/KiePMMLRegressionTest.scesim
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/src/test/resources/KiePMMLRegressionTest.scesim
@@ -440,7 +440,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/KiePMMLRegression.dmn</dmnFilePath>
+    <dmnFilePath>../../main/resources/KiePMMLRegression.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://kiegroup.org/dmn/_51A1FD67-8A67-4332-9889-B718BE8B7456</dmnNamespace>
     <dmnName>TestRegressionDMN</dmnName>

--- a/kogito-quarkus-examples/dmn-quarkus-example/src/test/resources/TrafficViolationTest.scesim
+++ b/kogito-quarkus-examples/dmn-quarkus-example/src/test/resources/TrafficViolationTest.scesim
@@ -753,7 +753,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/Traffic Violation.dmn</dmnFilePath>
+    <dmnFilePath>../../main/resources/Traffic Violation.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF</dmnNamespace>
     <dmnName>Traffic Violation</dmnName>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-consumer-example/src/test/resources/TrafficViolationTest.scesim
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-consumer-example/src/test/resources/TrafficViolationTest.scesim
@@ -753,7 +753,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>target/generated-resources/Traffic Violation.dmn</dmnFilePath>
+    <dmnFilePath>../../../target/generated-resources/Traffic Violation.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF</dmnNamespace>
     <dmnName>Traffic Violation</dmnName>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/src/test/resources/KiePMMLRegressionTest.scesim
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/src/test/resources/KiePMMLRegressionTest.scesim
@@ -440,7 +440,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/KiePMMLRegression.dmn</dmnFilePath>
+    <dmnFilePath>../../main/resources/KiePMMLRegression.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://kiegroup.org/dmn/_51A1FD67-8A67-4332-9889-B718BE8B7456</dmnNamespace>
     <dmnName>TestRegressionDMN</dmnName>

--- a/kogito-springboot-examples/dmn-springboot-example/src/test/resources/TrafficViolationTest.scesim
+++ b/kogito-springboot-examples/dmn-springboot-example/src/test/resources/TrafficViolationTest.scesim
@@ -753,7 +753,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/Traffic Violation.dmn</dmnFilePath>
+    <dmnFilePath>../../main/resources/Traffic Violation.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF</dmnNamespace>
     <dmnName>Traffic Violation</dmnName>


### PR DESCRIPTION
The upcoming version of the VSCode extension will change the file path management: all the file path references will be managed in a relative format.

I updated all the scesim files in the examples accordingly.

There's no impact on the engine side: paths are used in the editor only.