### PR TITLE
[Fix_#3569] Temporarily disabling SpecConversion example IT test

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
@@ -41,7 +41,7 @@
     <module>conversion-workflow</module>
     <module>conversion-workflow-full</module>
     <module>conversion-workflow-function</module>
-    <module>conversion-workflow-spec</module>
+<!--    <module>conversion-workflow-spec</module>-->
   </modules>
 
 </project>


### PR DESCRIPTION
Due to a strange snapshot issue handling by Quarkus when executing CI on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3572, we need to disable this and reenable once the PR that change the API is merged

