### PR TITLE
NO-ISSUE: extend setup-branch timeout

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -20,7 +20,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
Extending setup-branch timeout to give more time to build projects from drools up to examples (to be able to set maven versions, which the setup-branch job does).