### PR TITLE
[10.0.x] [incubator-kie-issues-1401] Fix build kogito-examples.build-and-test in kogito nightly.native folder

### DIFF
--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.8.4</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>10.0.999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>10.0.999-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/pom.xml
+++ b/kogito-quarkus-examples/pom.xml
@@ -133,7 +133,6 @@
         <module>dmn-quarkus-example</module>
         <module>dmn-resource-jar-quarkus-example</module>
         <module>dmn-multiple-models-quarkus-example</module>
-        <module>dmn-tracing-quarkus</module>
         <module>flexible-process-quarkus</module>
         <module>kogito-travel-agency</module>
         <module>onboarding-example</module>
@@ -174,7 +173,6 @@
         </property>
       </activation>
       <modules>
-        <module>trusty-tracing-quarkus-devservices</module>
       </modules>
     </profile>
 

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -36,8 +36,8 @@
     <quarkus.platform.version>3.8.4</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <kogito.bom.version>10.0.999-SNAPSHOT</kogito.bom.version>
+    <version.org.kie.kogito>10.0.999-SNAPSHOT</version.org.kie.kogito>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-annotations-description/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>10.0.999-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-camel-routes/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>10.0.999-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.kie.kogito.examples</groupId>
       <artifactId>serverless-workflow-examples-parent</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>10.0.999-SNAPSHOT</version>
       <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-type/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-dmn-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.kie.kogito.examples</groupId>
   <artifactId>serverless-workflow-examples-parent</artifactId>
-  <version>999-SNAPSHOT</version>
+  <version>10.0.999-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Kogito Example :: Serverless Workflow Examples :: Parent</name>
 

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-github-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-github-showcase/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-greeting-rpc-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-openvino-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>10.0.999-SNAPSHOT</kogito.bom.version>
     <maven.compiler.release>17</maven.compiler.release>
     <version.exec.plugin>1.6.0</version.exec.plugin>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-python-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-subflows-event/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,8 +44,8 @@
         <quarkus.platform.version>3.8.4</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-        <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-        <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+        <kogito.bom.version>10.0.999-SNAPSHOT</kogito.bom.version>
+        <version.org.kie.kogito>10.0.999-SNAPSHOT</version.org.kie.kogito>
         <maven.compiler.release>17</maven.compiler.release>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 

--- a/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito.examples</groupId>
     <artifactId>serverless-workflow-examples-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>10.0.999-SNAPSHOT</version>
     <relativePath>../serverless-workflow-examples-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Issue:
- https://github.com/apache/incubator-kie-issues/issues/1401

## Replaced remaining `999-SNAPSHOT` with `10.0.999-SNAPSHOT`
Why they were not updated by `mvnVersionsUpdateParentAndChildModules` / `mvnSetVersionProperty` in `Jenkinsfile.setup-branch`?
 -> for serverless-workflow examples, the `serverless-workflow-examples-parent` itself was not updated.
 -> for `dmn-tracing-quarkus` and `trusty-tracing-quarkus-devservices`, these examples are not in a valid state, so disabled in the parent pom (https://github.com/apache/incubator-kie-kogito-examples/pull/1930/files). Hence, they were not affected by `mvn` command. In other words, we can ignore the projects.

## Completely disabled `dmn-tracing-quarkus` and `trusty-tracing-quarkus-devservices`
In https://github.com/apache/incubator-kie-kogito-examples/pull/1930/files , `dmn-tracing-quarkus` and `trusty-tracing-quarkus-devservices` were disabled, but still existed in `native` profile and `kogito-apps-downstream` profile. This PR removes them.