### PR TITLE
Include usage of function returning not json objects in sonataflow examples

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/README.md
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/README.md
@@ -5,7 +5,7 @@
 This example contains a simple workflow service that illustrate JQ expression usage. 
 The service is described using JSON format as defined in the 
 [CNCF Serverless Workflow specification](https://github.com/serverlessworkflow/specification).
-The service accepts an array of complex numbers (x being the real coordinate and y the imaginary one) and return the max real coordinate. 
+The service accepts an array of complex numbers (x being the real coordinate and y the imaginary one) and return the square of the max real coordinate. 
 
 
 ## Installing and Running
@@ -84,11 +84,6 @@ curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d 
 ```
 
 
-In Quarkus you should see the log message printed:
-
-```text
-4
-```
 
 And the returned data will be something similar to 
 
@@ -96,7 +91,7 @@ And the returned data will be something similar to
 {
     "id": "9f30a25e-61d4-4e80-bc7c-eb04db51564c",
     "workflowdata": {
-        "result": 4
+        "result": 2.0
     }
 }
 ```

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/expression.sw.json
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/expression.sw.json
@@ -2,24 +2,14 @@
   "id": "expression",
   "version": "1.0",
   "name": "Workflow Expression example",
-  "constants" : {
-    "Dog" : {
-      "castellano" : "perro",
-      "leones": "perru",
-      "gallego" : "can",
-      "aragones" : "cocho",
-      "catalan" : "gos",
-      "vasco": "txakurra"
-    }
-  },
   "dataInputSchema" : "schema/expression.json",
   "description": "An example of how to use a JQ expression assignment",
-  "start": "squareState",
   "extensions" : [ {
       "extensionid": "workflow-output-schema",
       "outputSchema": "schema/result.json"
      }
   ],
+  "start": "max",
   "functions": [
     {
       "name": "max",
@@ -27,14 +17,14 @@
       "operation": "{max: .numbers | max_by(.x), min: .numbers | min_by(.y)}"
     },
     {
-      "name": "printMessage",
-      "type": "custom",
-      "operation": "sysout"
+      "name": "square",
+      "type": "expression",
+      "operation": ".number | sqrt"
     }
   ],
   "states": [
     {
-      "name": "squareState",
+      "name": "max",
       "type": "operation",
       "actions": [
         {
@@ -48,23 +38,22 @@
           }
         }
       ],
-      "transition": "finish"
+      "transition": "square"
     },
     {
-      "name": "finish",
+      "name": "square",
       "type": "operation",
       "stateDataFilter": {
-        "input": "{result: .number}"
+       "output": "{result}"
       },
       "actions": [
         {
-          "name": "printAction",
-          "functionRef": {
-            "refName": "printMessage",
-            "arguments": {
-              "message": ".result"
+          "name": "square",
+          "functionRef": "square"
+           ,
+            "actionDataFilter" : {
+              "toStateData": ".result" 
             }
-          }
         }
       ],
       "end": true

--- a/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/test/java/org/kie/kogito/examples/ExpressionRestIT.java
+++ b/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/test/java/org/kie/kogito/examples/ExpressionRestIT.java
@@ -39,7 +39,7 @@ class ExpressionRestIT {
                 .post("/expression")
                 .then()
                 .statusCode(201)
-                .body("workflowdata.result", is(4))
+                .body("workflowdata.result", is(2.0f))
                 .body("workflowdata.number", nullValue());
     }
 }

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/application.properties
@@ -22,6 +22,7 @@
 quarkus.native.native-image-xmx=8g
 # OpenAPI Properties
 quarkus.swagger-ui.always-include=true
+quarkus.devservices.enabled=false
 
 # OpenApi Client Properties
 quarkus.rest-client.subtraction_yaml.url=http://localhost:8181

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/fahrenheit-to-celsius.sw.json
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/fahrenheit-to-celsius.sw.json
@@ -43,6 +43,9 @@
           "functionRef": {
             "refName": "multiplication",
             "arguments":  "{ leftElement: .difference, rightElement: .multiplyValue }"
+          },
+          "actionDataFilter" : {
+             "results" : "{product: .}"
           }
         }
       ],

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/specs/multiplication.yaml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/specs/multiplication.yaml
@@ -40,14 +40,11 @@ paths:
      responses:
         "200":
           description: OK
-          content: 
-            application/json:
-              schema: 
-                type: object
-                properties:
-                  product:
-                    format: float
-                    type: number
+          content:
+            text/plain:
+              schema:
+                type: number
+                format: float
 components:
   schemas:
     MultiplicationOperation:

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/test/java/org/kie/kogito/serverless/OperationsMockService.java
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/test/java/org/kie/kogito/serverless/OperationsMockService.java
@@ -41,10 +41,10 @@ public class OperationsMockService implements QuarkusTestResourceLifecycleManage
     public Map<String, String> start() {
         multiplicationService =
                 this.startServer(8282,
-                        "{  \"product\": 37.808 }");
+                        "37.808", "text/plain");
         subtractionService =
                 this.startServer(8181,
-                        "{ \"difference\": 68.0 }");
+                        "{ \"difference\": 68.0 }", "application/json");
         return Collections.emptyMap();
     }
 
@@ -58,13 +58,13 @@ public class OperationsMockService implements QuarkusTestResourceLifecycleManage
         }
     }
 
-    private WireMockServer startServer(final int port, final String response) {
+    private WireMockServer startServer(final int port, final String response, final String contentType) {
         final WireMockServer server = new WireMockServer(port);
         server.start();
         server.stubFor(post(urlEqualTo("/"))
                 .withHeader(CloudEventExtensionConstants.PROCESS_ID, WireMock.matching(".*"))
                 .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Content-Type", contentType)
                         .withBody(response)));
         return server;
     }

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/multiplication/OperationResource.java
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/java/org/kie/kogito/examples/sw/temp/multiplication/OperationResource.java
@@ -31,31 +31,14 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @Path("/")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class OperationResource {
 
     @POST
-    @APIResponseSchema(value = OperationResource.Result.class, responseDescription = "MultiplicationResult", responseCode = "200")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Response doOperation(@NotNull MultiplicationOperation operation) {
-        return Response.ok(new Result(operation.getLeftElement() * operation.getRightElement())).build();
+        return Response.ok(operation.getLeftElement() * operation.getRightElement(), MediaType.TEXT_PLAIN).build();
     }
 
-    @RegisterForReflection
-    public static final class Result {
-
-        float product;
-
-        public Result() {
-        }
-
-        public Result(float product) {
-            this.product = product;
-        }
-
-        public float getProduct() {
-            return product;
-        }
-
-    }
+   
 }

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/main/resources/application.properties
@@ -21,6 +21,7 @@
 # quarkus.package.type=fast-jar
 quarkus.native.native-image-xmx=8g
 quarkus.swagger-ui.always-include=true
+quarkus.devservices.enabled=false
 
 # profile to pack this example into a container, to use it execute activate the maven container profile, -Dcontainer
 %container.quarkus.container-image.build=true

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/test/java/org/kie/kogito/examples/sw/temp/multiplication/OperationResourceIT.java
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/multiplication-service/src/test/java/org/kie/kogito/examples/sw/temp/multiplication/OperationResourceIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -32,13 +33,14 @@ class OperationResourceIT {
 
     @Test
     void testRestExample() {
-        final OperationResource.Result result = given()
+        Response result = given()
                 .contentType(ContentType.JSON)
-                .when()
                 .body(new MultiplicationOperation(2, 2))
-                .post("/")
                 .then()
-                .statusCode(200).extract().as(OperationResource.Result.class);
-        assertThat(result.getProduct(), is(4f));
+                .response().contentType(ContentType.TEXT)
+                .statusCode(200)
+                .when()
+                .post("/");
+        assertThat(Float.parseFloat(result.asString()), is(4f));
     }
 }


### PR DESCRIPTION
This illustrate the usage of funcions that returns not json objects, both for rest and jq functions

