### PR TITLE
[Fix #3694] Modifying for each example

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-foreach-quarkus/src/main/resources/foreach.sw.json
+++ b/serverless-workflow-examples/serverless-workflow-foreach-quarkus/src/main/resources/foreach.sw.json
@@ -13,7 +13,7 @@
     {
       "name": "increase",
       "type": "expression",
-      "operation": ".item + 1"
+      "operation": "$item + 1"
       
     }
   ],

--- a/serverless-workflow-examples/sonataflow-fluent/src/main/java/org/kie/kogito/serverless/workflow/examples/ForEachJava.java
+++ b/serverless-workflow-examples/sonataflow-fluent/src/main/java/org/kie/kogito/serverless/workflow/examples/ForEachJava.java
@@ -57,7 +57,7 @@ public class ForEachJava {
                 // then for each element in input names concatenate it with that message
                 .next(forEach(".names").loopVar("name").outputCollection(".messages")
                         // jq expression that suffix each name with the message retrieved from the file
-                        .action(call(expr("concat", ".name+.adviceMessage")))
+                        .action(call(expr("concat", "$name+.adviceMessage")))
                         // only return messages list as result of the flow
                         .outputFilter("{messages}"))
                 .end().build();


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/3694
Updates foreach example, replacing loop variable access. Before it was accesed as property using ".", now is accessed as variable using "$"
Merge with https://github.com/apache/incubator-kie-kogito-runtimes/pull/3696
