### PR TITLE
[10.0.x] CI duplicate maven configuration entries

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -139,7 +139,7 @@ void createSetupBranchJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
 
         IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
     ])
@@ -170,10 +170,10 @@ void setupReleaseDeployJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.RELEASE.name),
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
-        MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_URL}",
-        MAVEN_REPO_CREDS_ID: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_CREDS_ID}",
+        MAVEN_DEPLOY_REPOSITORY: Utils.getMavenArtifactsUploadRepositoryUrl(this, JobType.RELEASE.name),
+        MAVEN_REPO_CREDS_ID: Utils.getMavenArtifactsUploadRepositoryCredentialsId(this, JobType.RELEASE.name),
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -207,7 +207,7 @@ void setupReleasePromoteJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.RELEASE.name),
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
         MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
     ])


### PR DESCRIPTION
Adjusting branch.yaml configuration to split maven related configurations for nightly and release.

Part of ensemble:

- apache/incubator-kie-kogito-pipelines#1254
- apache/incubator-kie-drools#6130
- apache/incubator-kie-optaplanner#3133
- apache/incubator-kie-optaplanner-quickstarts#634
- apache/incubator-kie-kogito-runtimes#3737
- apache/incubator-kie-kogito-apps#2119
- apache/incubator-kie-kogito-examples#2025

The scope of changes:

- maven settings.xml reference (config file id pointing at pre-defined config file in jenkins)
- artifacts upload repository
  - url - mostly informational, should not be needed for deploy itself (inheriting that configuration from apache parent)
  - credentials-id - the important part, allowing to configure different credentials for nightly and release.

Notes:
- in some places the configuration variants denoted as nightly are used in other places too (e.g. setup-branch).

Follow-up:

- after this gets merged, incubator-kie-kogito-pipelines PR needs to be backported also into branches:
  - seed-drools-10.0.x
  - seed-kogito-10.0.x
  - seed-optaplanner-10.0.x 