### PR TITLE
[incubator-kie-issues-1682] Test cases in kogito repos GHA fail with …

### DIFF
--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/src/test/resources/application.properties
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/src/test/resources/application.properties
@@ -17,10 +17,4 @@
 # under the License.
 #
 
-# Quarkus
-quarkus.http.test-port=0
-
-# Temporary fix for test to pass due to issue in Quarkus classloading resolver
-quarkus.class-loading.parent-first-artifacts=org.testcontainers:testcontainers
-
 quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <container.image.kafka>${container.image.kafka}</container.image.kafka>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -154,6 +154,7 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
+            <container.image.kafka>${container.image.kafka}</container.image.kafka>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/test/resources/application.properties
@@ -21,3 +21,5 @@ quarkus.kogito.devservices.enabled=false
 
 kie.flyway.enabled=true
 quarkus.datasource.db-kind=postgresql
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
@@ -146,6 +146,7 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
+            <container.image.kafka>${container.image.kafka}</container.image.kafka>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -146,6 +146,7 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
+            <container.image.kafka>${container.image.kafka}</container.image.kafka>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/test/resources/application.properties
@@ -22,3 +22,5 @@ quarkus.http.test-port=0
 
 # Temporary fix for test to pass due to issue in Quarkus classloading resolver
 quarkus.class-loading.parent-first-artifacts=org.testcontainers:testcontainers
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-examples-parent/pom.xml
@@ -35,6 +35,7 @@
     <!-- Reproducible builds -->
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
+    <container.image.kafka>redpandadata/redpanda:v24.3.1</container.image.kafka>
   </properties>
 
 

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -162,6 +162,7 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
+            <container.image.kafka>${container.image.kafka}</container.image.kafka>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/test/resources/application.properties
@@ -17,10 +17,4 @@
 # under the License.
 #
 
-# Quarkus
-quarkus.http.test-port=0
-
-# Temporary fix for test to pass due to issue in Quarkus classloading resolver
-quarkus.class-loading.parent-first-artifacts=org.testcontainers:testcontainers
-
 quarkus.kafka.devservices.image-name=${container.image.kafka}


### PR DESCRIPTION
…"pull access denied for vectorized/redpanda"

### Issue:
- https://github.com/apache/incubator-kie-issues/issues/1682

### Cross repo PRs
- https://github.com/apache/incubator-kie-kogito-apps/pull/2162
- https://github.com/apache/incubator-kie-kogito-runtimes/pull/3812
- https://github.com/apache/incubator-kie-kogito-examples/pull/2043 (This one)

---
- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
