### PR TITLE
[Incubator-kie-issues-1869] Corrected the curl commands in the README file

### DIFF
--- a/kogito-quarkus-examples/dmn-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-quarkus-example/README.md
@@ -151,7 +151,7 @@ Given valid input:
 Curl command (using the JSON object above):
 
 ```sh
-curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d 'p1": {"Name":"Joe","Interests":["Golf"]}' http://localhost:8080/AllowedValuesChecksInsideCollection
+curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"p1": {"Name":"Joe","Interests":["Golf"]}}' http://localhost:8080/AllowedValuesChecksInsideCollection
 ```
 
 As response, interests information is returned.
@@ -185,7 +185,7 @@ With invalid value
 Curl command (using the JSON object above):
 
 ```sh
-curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d 'p1": {"Name":"Joe","Interests":["Dancing"]}' http://localhost:8080/AllowedValuesChecksInsideCollection
+curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"p1": {"Name":"Joe","Interests":["Dancing"]}}' http://localhost:8080/AllowedValuesChecksInsideCollection
 ```
 
 As response, error information is returned.

--- a/kogito-springboot-examples/dmn-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-springboot-example/README.md
@@ -106,7 +106,7 @@ Given valid input:
 Curl command (using the JSON object above):
 
 ```sh
-curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d 'p1": {"Name":"Joe","Interests":["Golf"]}' http://localhost:8080/AllowedValuesChecksInsideCollection
+curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"p1": {"Name":"Joe","Interests":["Golf"]}}' http://localhost:8080/AllowedValuesChecksInsideCollection
 ```
 
 As response, interests information is returned.
@@ -140,7 +140,7 @@ With invalid value
 Curl command (using the JSON object above):
 
 ```sh
-curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d 'p1": {"Name":"Joe","Interests":["Dancing"]}' http://localhost:8080/AllowedValuesChecksInsideCollection
+curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"p1": {"Name":"Joe","Interests":["Dancing"]}}' http://localhost:8080/AllowedValuesChecksInsideCollection
 ```
 
 As response, error information is returned.


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1869

The curl commands in dmn-quarkus-exmples and dmn-springboot-examples README file has syntax errors.
When we run these commands it says "Not able to deserialize data provided".

The instructions in the README files of dmn-quarkus-exmples and dmn-springboot-examples need to be updated 