### PR TITLE
[kie-issues#1967] Update wiremock dependency

### DIFF
--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -33,7 +33,7 @@
   <description>Kogito with DMN Knative Eventing - Quarkus</description>
 
   <properties>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
     <quarkus-plugin.version>3.15.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -116,8 +116,8 @@
     java.lang.NoSuchMethodError: 'com.github.fge.jackson.JsonNumEquals com.github.fge.jackson.JsonNumEquals.getInstance()'
     -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -31,7 +31,7 @@
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
   <description>Kogito with Knative Eventing - Quarkus</description>
   <properties>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
     <quarkus-plugin.version>3.15.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -114,8 +114,8 @@
     java.lang.NoSuchMethodError: 'com.github.fge.jackson.JsonNumEquals com.github.fge.jackson.JsonNumEquals.getInstance()'
     -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -104,8 +104,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/pom.xml
@@ -43,7 +43,7 @@
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-        <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+        <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
         <version.org.wiremock.webhooks>2.35.0</version.org.wiremock.webhooks>
     </properties>
 
@@ -97,8 +97,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${version.com.github.tomakehurst.wiremock}</version>
             <scope>test</scope>
         </dependency>

--- a/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-custom-function-knative/workflow/pom.xml
@@ -43,7 +43,7 @@
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <maven.compiler.release>17</maven.compiler.release>
         <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-        <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+        <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
         <version.org.wiremock.webhooks>2.35.0</version.org.wiremock.webhooks>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -119,8 +119,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${version.com.github.tomakehurst.wiremock}</version>
             <scope>test</scope>
         </dependency>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/pom.xml
@@ -50,7 +50,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
 
   <dependencyManagement>
@@ -127,8 +127,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-functions-quarkus/pom.xml
@@ -49,7 +49,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
 
   <dependencyManagement>
@@ -114,8 +114,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-funqy/sw-funqy-workflow/pom.xml
@@ -41,7 +41,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
 
   <dependencyManagement>
@@ -99,8 +99,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/aggregator/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/aggregator/pom.xml
@@ -29,6 +29,7 @@
   <name>Kogito Example :: Serverless Workflow Loan Broker Showcase :: Aggregator</name>
   <artifactId>serverless-workflow-loanbroker-showcase-aggregator</artifactId>
   <properties>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
     <skipITs>true</skipITs>
   </properties>
   <dependencyManagement>
@@ -101,7 +102,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
-      <version>${version.com.github.tomakehurst}</version>
+      <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/aggregator/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/aggregator/pom.xml
@@ -99,8 +99,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-flow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-flow/pom.xml
@@ -103,8 +103,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/pom.xml
@@ -50,7 +50,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <version.com.github.tomakehurst>2.33.2</version.com.github.tomakehurst>
+    <version.com.github.tomakehurst>3.13.0</version.com.github.tomakehurst>
     <version.org.testcontainers>1.17.3</version.org.testcontainers>
     <version.io.cloudevents>2.5.0</version.io.cloudevents>
     <!-- See: https://camel.apache.org/categories/Camel-Quarkus/ -->

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <version.org.assertj>3.22.0</version.org.assertj>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -149,8 +149,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml
@@ -46,7 +46,7 @@
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
   </properties>
@@ -109,8 +109,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -38,7 +38,7 @@
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -124,8 +124,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-service-calls-quarkus/pom.xml
@@ -47,7 +47,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
 
   <dependencyManagement>
@@ -108,8 +108,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/pom.xml
@@ -29,6 +29,9 @@
   </parent>
   <artifactId>stock-profit</artifactId>
   <name>Kogito Example :: Serverless Workflow Stock Profit :: Quarkus</name>
+  <properties>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.kie.sonataflow</groupId>
@@ -65,7 +68,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -101,8 +101,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -101,8 +101,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -101,8 +101,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -97,8 +97,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${version.com.github.tomakehurst.wiremock}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Updates wiremock dependency. Replacement PR for https://github.com/apache/incubator-kie-kogito-examples/pull/2102 to test all PR checks together. 

Related PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3931