### PR TITLE
NO-ISSUE: Replace BASH-specific syntax with POSIX syntax

### DIFF
--- a/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/README.md
@@ -29,7 +29,7 @@ In order to use it, please ensure you have Docker Compose installed on your mach
 
   Then run
 
-    docker-compose up
+    docker compose up
 
   Once all services bootstrap, the following ports will be assigned on your local machine:
   - PostgreSQL: 5432
@@ -46,12 +46,12 @@ Prometheus will also be available on http://localhost:9090, no authentication is
   
   To stop all services, simply run:
 
-    docker-compose stop
+    docker compose stop
     
   It is also recommended to remove any of stopped containers by running:
   
-    docker-compose rm
+    docker compose rm
     
   For more details please check the Docker Compose documentation.
   
-    docker-compose --help
+    docker compose --help

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/startServices.sh
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/docker-compose/startServices.sh
@@ -24,19 +24,19 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="latest"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 echo "Kogito Image version: ${KOGITO_VERSION}"
 echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
    echo "DOCKER_GATEWAY_HOST=kubernetes.docker.internal" >> ".env"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
    echo "DOCKER_GATEWAY_HOST=172.17.0.1" >> ".env"
 fi
 
@@ -85,4 +85,4 @@ else
     exit 1
 fi
 
-docker-compose up
+docker compose up

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/startServices.sh
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/startServices.sh
@@ -8,15 +8,15 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="latest"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 if [ -n "$1" ]; then
-  if [[ ("$1" == "infra") || ("$1" == "example")]];
+  if [ $1 = "infra" -o $1 = "example" ];
   then
     PROFILE="$1"
   else

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/README.md
@@ -77,9 +77,9 @@ Once all services bootstrap, the following ports will be assigned on your local 
 
 > **_NOTE:_**  This step requires the project to be compiled, please consider running a ```mvn clean install``` command on the project root before running the ```startServices.sh``` script for the first time or any time you modify the project.
 
-Once started you can simply stop all services by executing the ```docker-compose -f docker-compose-postgresql.yml stop```.
+Once started you can simply stop all services by executing the ```docker compose -f docker-compose-postgresql.yml stop```.
 
-All created containers can be removed by executing the ```docker-compose -f docker-compose-postgresql.yml rm```.
+All created containers can be removed by executing the ```docker compose -f docker-compose-postgresql.yml rm```.
 
 #### Run the Hiring example with PostgreSQL
 
@@ -161,9 +161,9 @@ Once all services bootstrap, the following ports will be assigned on your local 
 
 > **_NOTE:_**  This step requires the project to be compiled, please consider running a ```mvn clean install -Pinfinispan``` command on the project root before running the ```startServices.sh infinispan``` script for the first time or any time you modify the project.
 
-Once started you can simply stop all services by executing the ```docker-compose -f docker-compose-infinispan.yml stop```.
+Once started you can simply stop all services by executing the ```docker compose -f docker-compose-infinispan.yml stop```.
 
-All created containers can be removed by executing the ```docker-compose -f docker-compose-infinispan.yml rm```.
+All created containers can be removed by executing the ```docker compose -f docker-compose-infinispan.yml rm```.
 
 #### Run the Hiring example with Infinispan
 

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/docker-compose/startServices.sh
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/docker-compose/startServices.sh
@@ -25,12 +25,12 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="main"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 echo "Kogito Image version: ${KOGITO_VERSION}"
 echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
@@ -52,4 +52,4 @@ else
     exit 1
 fi
 
-docker-compose -f docker-compose-postgresql.yml up
+docker compose -f docker-compose-postgresql.yml up

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/README.md
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/README.md
@@ -24,7 +24,7 @@ Optionally and for convenience, a docker-compose [configuration file](docker-com
 provided in the path [docker-compose/](docker-compose/), where you can just run the command from there:
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 In this way a container for Kafka will be started on port 9092.
@@ -40,7 +40,7 @@ Optionally and for convenience, a docker-compose [configuration file](docker-com
 provided in the path [docker-compose/](docker-compose/), where you can just run the command from there:
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 In this way a container for PostgreSQL will be started on port 5432.
@@ -84,7 +84,7 @@ For Linux and MacOS:
 3. Run the ```startServices.sh``` script
 
 ```bash
-cd docker-compose && sh ./startServices.sh
+cd docker compose && sh ./startServices.sh
 ```
 
 Tip: If you get permission denied while creating the postgres container, consider to use SELinux context.
@@ -107,9 +107,9 @@ Once all services bootstrap, the following ports will be assigned on your local 
 
 > **_NOTE:_**  This step requires the project to be compiled, please consider running a ```mvn clean package -Dcontainer``` command on the project root before running the ```startServices.sh``` script for the first time or any time you modify the project.
 
-Once started you can simply stop all services by executing the ```docker-compose -f docker-compose.yml stop```.
+Once started you can simply stop all services by executing the ```docker compose -f docker-compose.yml stop```.
 
-All created containers can be removed by executing the ```docker-compose -f docker-compose.yml rm```.
+All created containers can be removed by executing the ```docker compose -f docker-compose.yml rm```.
 
 
 ### Compile and Run using Local Native Image

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/docker-compose/startServices.sh
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/docker-compose/startServices.sh
@@ -25,14 +25,14 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="latest"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 echo "Kogito Image version: ${KOGITO_VERSION}"
 echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
 
-docker-compose -f docker-compose.yml up
+docker compose -f docker-compose.yml up

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/README.md
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/README.md
@@ -56,7 +56,7 @@ NOTE: Data Index graphql UI will be available in http://localhost:8180/graphiql/
 You should start all the services before you execute any of the **Data Index** example. To do that please execute:
 
 ```sh
-mvn clean package -P container
+mvn clean package -Pcontainer
 ```
 
 For Linux and MacOS:

--- a/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/docker-compose/startServices.sh
+++ b/serverless-workflow-examples/serverless-workflow-data-index-persistence-addon-quarkus/docker-compose/startServices.sh
@@ -23,14 +23,14 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="latest"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 echo "Kogito Image version: ${KOGITO_VERSION}"
 echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
 
-docker-compose -f docker-compose.yml up
+docker compose -f docker-compose.yml up

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/README.md
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/README.md
@@ -88,17 +88,17 @@ NOTE: Data Index graphql UI will be available in http://localhost:8180/q/graphql
 You should start all the services before you execute any of the **Data Index** example. To do that please execute:
 
 ```sh
-mvn clean package -P container,data-index-addon 
+mvn clean package -Pcontainer,data-index-addon 
 ```
 
 For Linux and MacOS:
 
 1. Open a Terminal
 2. Go to docker-compose folder
-3. Run ```docker-compose up```
+3. Run ```docker compose up```
 
 ```bash
-cd docker-compose && docker-compose up
+cd docker-compose && docker compose up
 ```
 
 TIP: If you get a `permission denied` error while creating the postgresql container, consider using SELinux context.
@@ -144,7 +144,7 @@ For Linux and MacOS:
 or 
 
 ```bash
-cd docker-compose && ./startServices.sh
+cd docker compose && ./startServices.sh
 ```
 
 Once all services bootstrap, the following ports will be assigned on your local machine:

--- a/serverless-workflow-examples/serverless-workflow-data-index-quarkus/docker-compose/startServices.sh
+++ b/serverless-workflow-examples/serverless-workflow-data-index-quarkus/docker-compose/startServices.sh
@@ -25,14 +25,14 @@ PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -D
 
 echo "Project version: ${PROJECT_VERSION}"
 
-if [[ $PROJECT_VERSION == *SNAPSHOT ]];
-then
-  KOGITO_VERSION="latest"
-else
-  KOGITO_VERSION=${PROJECT_VERSION%.*}
-fi
+case $PROJECT_VERSION in
+ *SNAPSHOT)
+   KOGITO_VERSION="main" ;;
+ *)
+   KOGITO_VERSION=${PROJECT_VERSION%.*} ;;
+esac
 
 echo "Kogito Image version: ${KOGITO_VERSION}"
 echo "KOGITO_VERSION=${KOGITO_VERSION}" > ".env"
 
-docker-compose -f docker-compose-with-data-index.yml up
+docker compose -f docker-compose-with-data-index.yml up


### PR DESCRIPTION
Some scripts for starting docker compose don't work on Ubuntu or other systems, that don't use BASH as their default shell. Thus replacing BASH-specific syntax with the POSIX compliant one.

Also updating out-of-date `docker-compose` with newer `docker compose` command in affected project. 