### PR TITLE
[NO-ISSUE] replace legacy 'docker-compose' with 'docker compose'

### DIFF
--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/README.md
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/README.md
@@ -10,7 +10,7 @@ You will need:
   - Java 17+ installed 
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.6+ installed
-  - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker-compose` script provided in this example).
+  - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
   
 ### How to enable the feature
 
@@ -63,9 +63,9 @@ Custom dashboards will be available in the grafana panel, together with auto-gen
 
 ### Compile and Run in Local Dev Mode
 
-It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
+It is possible to use `docker compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
 1. Run `mvn clean package` to build the project and generate dashboards. A docker image tagged `org.kie.kogito.examples/dmn-drools-quarkus-metrics-example:1.0` will be built (docker must be installed on your system).
-2. Run `docker-compose up` to start the applications. 
+2. Run `docker compose up` to start the applications. 
 
 The volumes of the grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are properly loaded at startup.
 
@@ -99,4 +99,4 @@ curl -X POST 'http://localhost:8080/LoanEligibility' -H 'Content-Type: applicati
 
 the service will return the decision results.  
 
-If you are using the `docker-compose` script we provided, go to `localhost:3000` and have a look at your dashboards.
+If you are using the `docker compose` script we provided, go to `localhost:3000` and have a look at your dashboards.

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
@@ -66,7 +66,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
@@ -152,9 +152,9 @@ Once all services bootstrap, the following ports will be assigned on your local 
 
 > **_NOTE:_**  This step requires the project to be compiled, please consider running a ```mvn clean install``` command on the project root before running the ```startServices.sh``` script for the first time or any time you modify the project.
 
-Once started you can simply stop all services by executing the ```docker-compose stop```.
+Once started you can simply stop all services by executing the ```docker compose stop```.
 
-All created containers can be removed by executing the ```docker-compose rm```.
+All created containers can be removed by executing the ```docker compose rm```.
 
 ### Using Keycloak as Authentication Server
 

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
@@ -98,9 +98,9 @@ Once all services bootstrap, the following ports will be assigned on your local 
 
 > **_NOTE:_**  This step requires the project to be compiled, please consider running a ```mvn clean install``` command on the project root before running the ```startServices.sh``` script for the first time or any time you modify the project.
 
-Once started you can simply stop all services by executing the ```docker-compose stop```.
+Once started you can simply stop all services by executing the ```docker compose stop```.
 
-All created containers can be removed by executing the ```docker-compose rm```.
+All created containers can be removed by executing the ```docker compose rm```.
 
 ### Using Keycloak as Authentication Server
 

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/README.md
@@ -66,7 +66,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/README.md
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/README.md
@@ -43,5 +43,5 @@ to stop the services and remove the containers.
 For more details please check the Docker Compose documentation.
 
 ```shell
-docker-compose --help
+docker compose --help
 ```

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/startServices.sh
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/docker-compose/startServices.sh
@@ -16,7 +16,7 @@ case $PROJECT_VERSION in
 esac
 
 if [ -n "$1" ]; then
-  if [ $1 = "infra" -o $1 = "example" ];
+  if [ "$1" = "infra" -o "$1" = "example" ];
   then
     PROFILE="$1"
   else

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
@@ -66,7 +66,7 @@ https://kafka.apache.org/quickstart
 
 Alternatively, you can use the provided Docker Compose file in src/main/docker. To get Kafka started in the localhost port 9092, simply run:
 ```sh
-docker-compose up
+docker compose up
 ```
 
 ## Build and run

--- a/kogito-quarkus-examples/process-monitoring-quarkus/README.md
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/README.md
@@ -11,7 +11,7 @@ You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
 - Maven 3.9.6+ installed
-- Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker-compose` script provided in this example).
+- Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
 
 ### How to enable the feature
 
@@ -53,10 +53,10 @@ You can use these default dashboards, or you can personalize them and use your c
 
 ### Compile and Run in Local Dev Mode
 
-It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the Grafana container:
+It is possible to use `docker compose` to demonstrate how to inject the generated dashboards in the volume of the Grafana container:
 
 1. Run `mvn clean package` to build the project and generate dashboards.
-2. Run `docker-compose up` to start the applications.
+2. Run `docker compose up` to start the applications.
 
 The volumes of the Grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are automatically loaded at startup.
 

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/README.md
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/README.md
@@ -17,7 +17,7 @@ mvn clean package
 
 2. Deploy Kogito App, MongoDB, Debezium and Kafka
 ```shell
-docker-compose up
+docker compose up
 ```
 
 3. Check if Debezium is in `RUNNING` state
@@ -40,7 +40,7 @@ curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : f
 
 7. Shut down the cluster
 ```shell
-docker-compose down
+docker compose down
 ```
 
 ## Kogito App Example Usage

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/docker-clean.sh
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/docker-clean.sh
@@ -20,8 +20,8 @@
 
 # Helper script to remove any cache from previous build
 
-docker-compose stop
-docker-compose rm
+docker compose stop
+docker compose rm
 docker rmi kogito/outbox/quarkus/sidecar
 docker rmi org.kie.kogito.examples/process-outbox-mongodb-quarkus:1.0
 docker rmi kogito/outbox/quarkus/mongodb

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/README.md
@@ -69,7 +69,7 @@ For more details you can check [applications.properties](src/main/resources/appl
 Optionally and for convenience, a docker-compose [configuration file](docker-compose/docker-compose.yml) is
  provided in the path [docker-compose/](docker-compose/), where you can just run the command from there:
   ```sh
-  docker-compose up
+  docker compose up
   ```  
   In this way a container for PostgreSQL running on port 5432, along with PgAdmin, running on port
    8055 to allow the database management.

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/README.md
@@ -66,7 +66,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
@@ -10,7 +10,7 @@ You will need:
   - Java 11+ installed 
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.8.6+ installed
-  - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker-compose` script provided in this example).
+  - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
 
 ### How to enable the feature
 
@@ -63,9 +63,9 @@ Custom dashboards will be available in the grafana panel, together with auto-gen
 
 ### Compile and Run in Local Dev Mode
 
-It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
+It is possible to use `docker compose` to demonstrate how to inject the generated dashboards in the volume of the grafana container:
 1. Run `mvn clean package -Dcontainer` to build the project and generate dashboards.  A docker image tagged `org.kie.kogito.examples/dmn-drools-springboot-metrics-example:1.0` will be built (docker must be installed on your system).
-2. Run `docker-compose up` to start the applications. 
+2. Run `docker compose up` to start the applications. 
 
 The volumes of the grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are properly loaded at startup.
 
@@ -99,4 +99,4 @@ curl -X POST 'http://localhost:8080/LoanEligibility' -H 'Content-Type: applicati
 
 the service will return the decision results.  
 
-If you are using the `docker-compose` script we provided, go to `localhost:3000` and have a look at your dashboards.
+If you are using the `docker compose` script we provided, go to `localhost:3000` and have a look at your dashboards.

--- a/kogito-springboot-examples/dmn-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/README.md
@@ -55,7 +55,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.

--- a/kogito-springboot-examples/pmml-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/README.md
@@ -55,7 +55,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.

--- a/kogito-springboot-examples/process-monitoring-springboot/README.md
+++ b/kogito-springboot-examples/process-monitoring-springboot/README.md
@@ -56,7 +56,7 @@ You can use these default dashboards, or you can personalize them and use your c
 It is possible to use `docker-compose` to demonstrate how to inject the generated dashboards in the volume of the Grafana container:
 
 1. Run `mvn clean package` to build the project and generate dashboards.
-2. Run `docker-compose up` to start the applications.
+2. Run `docker compose up` to start the applications.
 
 The volumes of the Grafana container are properly set in the `docker-compose.yml` file, so that the dashboards are automatically loaded at startup.
 

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/README.md
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/README.md
@@ -17,7 +17,7 @@ mvn clean package -Dcontainer
 
 2. Deploy Kogito App, MongoDB, Debezium and Kafka
 ```shell
-docker-compose up
+docker compose up
 ```
 
 3. Check if Debezium is in `RUNNING` state
@@ -40,7 +40,7 @@ curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : f
 
 7. Shut down the cluster
 ```shell
-docker-compose down
+docker compose down
 ```
 
 ## Kogito App Example Usage

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/docker-clean.sh
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/docker-clean.sh
@@ -20,8 +20,8 @@
 
 # Helper script to remove any cache from previous build
 
-docker-compose stop
-docker-compose rm
+docker compose stop
+docker compose rm
 docker rmi kogito/outbox/springboot/sidecar
 docker rmi org.kie.kogito.examples/process-outbox-mongodb-springboot:1.0
 docker rmi kogito/outbox/springboot/mongodb

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
@@ -67,9 +67,9 @@ property `kogito.persistence.auto.ddl=true`.
 For more details you can check [applications.properties](src/main/resources/application.properties).
 
 Optionally and for convenience, a docker-compose [configuration file](docker-compose/docker-compose.yml) is
- provided in the path [docker-compose/](docker-compose/), where you can just run the command from there:
+ provided in the path [docker compose/](docker-compose/), where you can just run the command from there:
   ```sh
-  docker-compose up
+  docker compose up
   ```  
   In this way a container for PostgreSQL running on port 5432, along with PgAdmin, running on port
    8055 to allow the database management.

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
@@ -55,7 +55,7 @@ There's a useful [docker-compose.yml](docker-compose.yml) in the root that start
 Simply start it with this command from the root of the repo:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Once everything is started you can check the data contained in your small Kafka instance via [Kafdrop](https://github.com/obsidiandynamics/kafdrop) at `http://localhost:9000/`.


### PR DESCRIPTION
Follows up on #2111, marking this as draft until #2111 is merged