### PR TITLE
kie-issues#2193: Preliminary changes to enable Gradle and improvements to `kogito-maven-plugin`

### DIFF
--- a/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
+++ b/kogito-springboot-examples/decisiontable-springboot-example/pom.xml
@@ -80,7 +80,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-15-springboot-example/pom.xml
@@ -107,7 +107,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/pom.xml
@@ -106,7 +106,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/pom.xml
@@ -102,7 +102,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-listener-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-listener-springboot/pom.xml
@@ -81,7 +81,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/pom.xml
@@ -97,7 +97,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/dmn-springboot-consumer-example/pom.xml
@@ -105,7 +105,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-springboot-example/pom.xml
+++ b/kogito-springboot-examples/dmn-springboot-example/pom.xml
@@ -86,7 +86,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
+++ b/kogito-springboot-examples/dmn-tracing-springboot/pom.xml
@@ -97,7 +97,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/flexible-process-springboot/pom.xml
+++ b/kogito-springboot-examples/flexible-process-springboot/pom.xml
@@ -96,7 +96,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -104,7 +104,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/pom.xml
@@ -92,7 +92,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/pmml-springboot-example/pom.xml
+++ b/kogito-springboot-examples/pmml-springboot-example/pom.xml
@@ -86,7 +86,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-business-calendar-springboot-example/pom.xml
@@ -75,7 +75,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-business-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-business-rules-springboot/pom.xml
@@ -94,7 +94,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -103,7 +103,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rules-springboot/pom.xml
@@ -98,7 +98,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-decisions-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-springboot/pom.xml
@@ -98,7 +98,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/pom.xml
@@ -121,7 +121,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/pom.xml
@@ -122,7 +122,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/pom.xml
@@ -123,7 +123,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/pom.xml
@@ -116,7 +116,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-monitoring-springboot/pom.xml
+++ b/kogito-springboot-examples/process-monitoring-springboot/pom.xml
@@ -95,7 +95,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
+++ b/kogito-springboot-examples/process-outbox-mongodb-springboot/pom.xml
@@ -115,7 +115,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-performance-springboot/pom.xml
+++ b/kogito-springboot-examples/process-performance-springboot/pom.xml
@@ -133,7 +133,6 @@ https://repo.maven.apache.org/maven2: Did not attempt to download because of a p
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/pom.xml
@@ -118,7 +118,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -89,7 +89,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-scripts-springboot/pom.xml
+++ b/kogito-springboot-examples/process-scripts-springboot/pom.xml
@@ -89,7 +89,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-service-calls-springboot/pom.xml
+++ b/kogito-springboot-examples/process-service-calls-springboot/pom.xml
@@ -89,7 +89,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-springboot-example/pom.xml
+++ b/kogito-springboot-examples/process-springboot-example/pom.xml
@@ -108,7 +108,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-timer-springboot/pom.xml
+++ b/kogito-springboot-examples/process-timer-springboot/pom.xml
@@ -123,7 +123,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/pom.xml
@@ -147,7 +147,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-usertasks-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-springboot/pom.xml
@@ -89,7 +89,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/pom.xml
@@ -110,7 +110,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/pom.xml
@@ -104,7 +104,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-scesim-springboot-example/pom.xml
@@ -88,7 +88,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/pom.xml
@@ -81,7 +81,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/pom.xml
@@ -95,7 +95,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>

--- a/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
+++ b/kogito-springboot-examples/ruleunit-springboot-example/pom.xml
@@ -81,7 +81,6 @@
         <version>${version.org.kie.kogito}</version>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>generateModel</goal>
             </goals>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/2193

- https://github.com/apache/incubator-kie-kogito-runtimes/pull/4166
- https://github.com/apache/incubator-kie-kogito-examples/pull/2154

Removed all hardcoded <phase>compile</phase>, that are useless as the default value defined in the MOJO is one used.