### PR TITLE
[ISSUE-2172] Bump testcontainers version to 2.0.3 in examples with devservices and disable when not needed

### DIFF
--- a/kogito-quarkus-examples/rules-quarkus-helloworld/src/test/resources/application.properties
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/pom.xml
@@ -47,6 +47,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
   <dependencyManagement>
@@ -64,6 +65,11 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-callback-quarkus/src/test/resources/application.properties
@@ -18,8 +18,11 @@
 #
 
 quarkus.kogito.devservices.enabled=false
+quarkus.keycloak.devservices.enabled=false
 
 kie.flyway.enabled=true
 quarkus.datasource.db-kind=postgresql
+kogito.events.transaction.enabled=false
+
 
 quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/serverless-workflow-examples/serverless-workflow-compensation-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-compensation-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-consuming-events-over-http-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/pom.xml
@@ -47,6 +47,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
   <dependencyManagement>
@@ -64,6 +65,11 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus-mongodb/src/test/resources/application.properties
@@ -19,6 +19,7 @@
 
 # Quarkus
 quarkus.http.test-port=0
+quarkus.keycloak.devservices.enabled=false
 
 # Temporary fix for test to pass due to issue in Quarkus classloading resolver
 quarkus.class-loading.parent-first-artifacts=org.testcontainers:testcontainers

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/pom.xml
@@ -47,6 +47,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
   <dependencyManagement>
@@ -64,6 +65,11 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-correlation-quarkus/src/test/resources/application.properties
@@ -24,3 +24,4 @@ quarkus.http.test-port=0
 quarkus.class-loading.parent-first-artifacts=org.testcontainers:testcontainers
 
 quarkus.kafka.devservices.image-name=${container.image.kafka}
+quarkus.keycloak.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-error-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-error-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-events-quarkus/pom.xml
@@ -48,6 +48,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.3.1</version.failsafe.plugin>
     <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
   <dependencyManagement>
@@ -65,6 +66,11 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-functions-events-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-greeting-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-greeting-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-hello-world/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-hello-world/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-flow/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-loanbroker-showcase/loanbroker-flow/src/test/resources/application.properties
@@ -18,6 +18,7 @@
 #
 
 quarkus.http.test-port=0
+quarkus.devservices.enabled=false
 
 # Act as a placeholder to avoid triggering Kubernetes Service Discovery during test runs
 # The actual URLs are set by the Quarkus Test Runner

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/pom.xml
@@ -52,6 +52,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
   <modules>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/pom.xml
@@ -54,6 +54,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-flow/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
-quarkus.devservices.enabled=false
+quarkus.keycloak.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-newsletter-subscription/subscription-service/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service/pom.xml
@@ -41,6 +41,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>3.5.2</version.failsafe.plugin>
     <version.org.assertj>3.22.0</version.org.assertj>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -57,6 +58,11 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/pom.xml
@@ -50,8 +50,8 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.surefire.plugin>3.3.1</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <testcontainers.version>1.19.7</testcontainers.version>
     <okhttp.version>4.12.0</okhttp.version>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -62,7 +62,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
       <dependency>
         <groupId>${kogito.bom.group-id}</groupId>
         <artifactId>${kogito.bom.artifact-id}</artifactId>
@@ -70,13 +69,10 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${testcontainers.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/serverless-workflow-examples/serverless-workflow-order-processing/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-order-processing/src/test/resources/application.properties
@@ -20,3 +20,5 @@
 quarkus.log.level=INFO
 
 mp.messaging.outgoing.kogito_outgoing_stream.url=http://0.0.0.0:8181
+
+quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-parallel-execution/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-parallel-execution/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/pom.xml
@@ -49,6 +49,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.release>17</maven.compiler.release>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
+    <version.org.testcontainers>2.0.3</version.org.testcontainers>
   </properties>
 
 </project>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/pom.xml
@@ -56,6 +56,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-answer-service/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
-quarkus.devservices.enabled=false
+quarkus.keycloak.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/pom.xml
@@ -57,6 +57,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-qas-service-showcase/query-service/src/test/resources/application.properties
@@ -18,3 +18,4 @@
 #
 
 quarkus.kafka.devservices.image-name=${container.image.kafka}
+quarkus.keycloak.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-saga-quarkus/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-saga-quarkus/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-stock-profit/stock-profit/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-full/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-function/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow-spec/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/conversion-workflow/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-temperature-conversion/subtraction-service/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false

--- a/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/src/test/resources/application.properties
+++ b/serverless-workflow-examples/serverless-workflow-testing-with-rest-assured/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 #
 
 # Quarkus
-quarkus.http.test-port=0
 quarkus.devservices.enabled=false


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Fixes https://github.com/apache/incubator-kie-kogito-examples/issues/2172


Also fixes this issue in other tests: 
`
UnixSocketClientProviderStrategy: failed with exception BadRequestException (Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
`

This is due to Docker Engine update to 29 version, recently: https://github.com/actions/runner-images/issues/13474.

Therefore, we need to update to `testcontainers` **2.0.3** when using devservices, and also disable devservices for thos examples that are not using them (starting Keycloak container takes around 20 seconds, so it will save several minutes in total...)
