### PR TITLE
[incubator-kie-issues#2259] Dumping dependency trees to different file

### DIFF
--- a/.github/workflows/pr-kogito-examples.yml
+++ b/.github/workflows/pr-kogito-examples.yml
@@ -72,7 +72,9 @@ jobs:
           report_paths: '**/*-reports/TEST-*.xml'
       - name: Upload Dependency Trees
         uses: actions/upload-artifact@v4
+        env:
+          DEPENDENCY_TREE_FILE: 'mvn_dependency_tree_${{ matrix.job_name }}_${{ matrix.os }}.txt'
         if: ${{ always() }}
         with:
-          name: dependency-trees-logs
+          name: dependency-trees-logs_${{ matrix.job_name }}_${{ matrix.os }}
           path: '**/${{ env.DEPENDENCY_TREE_FILE }}'

--- a/.github/workflows/pr-kogito-examples.yml
+++ b/.github/workflows/pr-kogito-examples.yml
@@ -43,6 +43,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.job_name }} (${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }})
+    env:
+      DEPENDENCY_TREE_FILE: 'mvn_dependency_tree_${{ matrix.job_name }}_${{ matrix.os }}.txt'
     steps:
       - name: Clean Disk Space
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/ubuntu-disk-space@main
@@ -60,7 +62,6 @@ jobs:
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         env:
           KOGITO_EXAMPLES_SUBFOLDER_POM: ${{ matrix.env_KOGITO_EXAMPLES_SUBFOLDER_POM }}
-          DEPENDENCY_TREE_FILE: 'mvn_dependency_tree_${{ matrix.job_name }}_${{ matrix.os }}.txt'
         with:
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -72,8 +73,6 @@ jobs:
           report_paths: '**/*-reports/TEST-*.xml'
       - name: Upload Dependency Trees
         uses: actions/upload-artifact@v4
-        env:
-          DEPENDENCY_TREE_FILE: 'mvn_dependency_tree_${{ matrix.job_name }}_${{ matrix.os }}.txt'
         if: ${{ always() }}
         with:
           name: dependency-trees-logs_${{ matrix.job_name }}_${{ matrix.os }}

--- a/.github/workflows/pr-kogito-examples.yml
+++ b/.github/workflows/pr-kogito-examples.yml
@@ -69,3 +69,9 @@ jobs:
         if: ${{ always() }}
         with:
           report_paths: '**/*-reports/TEST-*.xml'
+      - name: Upload Dependency Trees
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: dependency-trees-logs
+          path: '**/mvn_dependency_tree.txt'

--- a/.github/workflows/pr-kogito-examples.yml
+++ b/.github/workflows/pr-kogito-examples.yml
@@ -60,6 +60,7 @@ jobs:
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         env:
           KOGITO_EXAMPLES_SUBFOLDER_POM: ${{ matrix.env_KOGITO_EXAMPLES_SUBFOLDER_POM }}
+          DEPENDENCY_TREE_FILE: 'mvn_dependency_tree_${{ matrix.job_name }}_${{ matrix.os }}.txt'
         with:
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -74,4 +75,4 @@ jobs:
         if: ${{ always() }}
         with:
           name: dependency-trees-logs
-          path: '**/mvn_dependency_tree.txt'
+          path: '**/${{ env.DEPENDENCY_TREE_FILE }}'


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-issues/issues/2259


With this PR:
1. dependency tree are not dumped on the build log anymore but on a specific file
2. a new job "Upload Dependency Trees" is execute after the build
3. the dependency tree log could be downloaded from the link that will be shown inside the "Upload Dependency Trees" job

Other PRs in the ensamble

https://github.com/apache/incubator-kie-kogito-pipelines/pull/1295
https://github.com/apache/incubator-kie-drools/pull/6593
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4204
https://github.com/apache/incubator-kie-kogito-apps/pull/2304