### PR TITLE
[issue#2170] Fix OpenTelemetry tests in CI by setting metrics exporter to none

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/JaegerTestResource.java
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/JaegerTestResource.java
@@ -86,6 +86,9 @@ public class JaegerTestResource implements QuarkusTestResourceLifecycleManager {
         cfg.put("quarkus.otel.exporter.otlp.traces.endpoint", otlpGrpcEndpoint);
         cfg.put("quarkus.otel.exporter.otlp.traces.protocol", "grpc");
 
+        // OpenTelemetry SDK autoconfigure
+        cfg.put("otel.metrics.exporter", "none");
+
         // Optional: make Jaeger query base URL available to the tests
         cfg.put("test.jaeger.query.base-url", jaegerQueryBaseUrl);
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Fixes https://github.com/apache/incubator-kie-kogito-examples/issues/2170