### PR TITLE
[Fix_#2200] Fix OpenTelemetry tests in CI by setting otel.traces.exporter to none

### DIFF
--- a/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/JaegerTestResource.java
+++ b/serverless-workflow-examples/serverless-workflow-opentelemetry-jaeger-quarkus/src/test/java/org/kie/kogito/examples/sw/opentelemetry/jaeger/JaegerTestResource.java
@@ -88,6 +88,7 @@ public class JaegerTestResource implements QuarkusTestResourceLifecycleManager {
 
         // OpenTelemetry SDK autoconfigure
         cfg.put("otel.metrics.exporter", "none");
+        cfg.put("otel.traces.exporter", "none");
 
         // Optional: make Jaeger query base URL available to the tests
         cfg.put("test.jaeger.query.base-url", jaegerQueryBaseUrl);


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Fixes: https://github.com/apache/incubator-kie-kogito-examples/issues/2200


