### PR TITLE
[incubator-kie-issues#2288] - Springboot 4.0.x upgrade 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ bin/
 /target
 /local
 
+# Gradle
+build/
+.gradle/
+
 # Eclipse, Netbeans and IntelliJ files
 .*
 !.env

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/build.gradle
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/build.gradle
@@ -33,6 +33,13 @@ repositories {
   mavenLocal()
 }
 
+// TODO Spring Boot 4 ships Groovy 5.0.4 via spring-boot-dependencies, but RestAssured 5.5.6
+// (managed by kogito-dependencies-bom) was compiled against Groovy 4 and hits a NullPointerException
+// in MetaClassImpl.getMetaProperty under Groovy 5. The Maven side already pins Groovy 4.0.29 in
+// kogito-spring-boot-bom — match that here so the Gradle classpath is consistent. Drop once
+// RestAssured ships a Groovy-5-compatible release.
+ext['groovy.version'] = '4.0.29'
+
 dependencies {
   implementation platform("org.kie.kogito:kogito-spring-boot-bom:${kogitoVersion}")
   implementation("org.springframework.boot:spring-boot-starter-web")

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/build.gradle
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/build.gradle
@@ -33,11 +33,8 @@ repositories {
   mavenLocal()
 }
 
-// TODO Spring Boot 4 ships Groovy 5.0.4 via spring-boot-dependencies, but RestAssured 5.5.6
-// (managed by kogito-dependencies-bom) was compiled against Groovy 4 and hits a NullPointerException
-// in MetaClassImpl.getMetaProperty under Groovy 5. The Maven side already pins Groovy 4.0.29 in
-// kogito-spring-boot-bom — match that here so the Gradle classpath is consistent. Drop once
-// RestAssured ships a Groovy-5-compatible release.
+// Pin Groovy 4 to match the Maven side: RestAssured 5.5.6 is compiled against Groovy 4 and trips
+// a NullPointerException under Groovy 5. TODO drop when RestAssured ships a Groovy 5 release.
 ext['groovy.version'] = '4.0.29'
 
 dependencies {

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=3.5.12
+springBootVersion=4.0.5
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/build.gradle
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/build.gradle
@@ -33,6 +33,13 @@ repositories {
   mavenLocal()
 }
 
+// TODO Spring Boot 4 ships Groovy 5.0.4 via spring-boot-dependencies, but RestAssured 5.5.6
+// (managed by kogito-dependencies-bom) was compiled against Groovy 4 and hits a NullPointerException
+// in MetaClassImpl.getMetaProperty under Groovy 5. The Maven side already pins Groovy 4.0.29 in
+// kogito-spring-boot-bom — match that here so the Gradle classpath is consistent. Drop once
+// RestAssured ships a Groovy-5-compatible release.
+ext['groovy.version'] = '4.0.29'
+
 dependencies {
   implementation platform("org.kie.kogito:kogito-spring-boot-bom:${kogitoVersion}")
   implementation("org.springframework.boot:spring-boot-starter-web")

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/build.gradle
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/build.gradle
@@ -33,11 +33,8 @@ repositories {
   mavenLocal()
 }
 
-// TODO Spring Boot 4 ships Groovy 5.0.4 via spring-boot-dependencies, but RestAssured 5.5.6
-// (managed by kogito-dependencies-bom) was compiled against Groovy 4 and hits a NullPointerException
-// in MetaClassImpl.getMetaProperty under Groovy 5. The Maven side already pins Groovy 4.0.29 in
-// kogito-spring-boot-bom — match that here so the Gradle classpath is consistent. Drop once
-// RestAssured ships a Groovy-5-compatible release.
+// Pin Groovy 4 to match the Maven side: RestAssured 5.5.6 is compiled against Groovy 4 and trips
+// a NullPointerException under Groovy 5. TODO drop when RestAssured ships a Groovy 5 release.
 ext['groovy.version'] = '4.0.29'
 
 dependencies {

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=3.5.12
+springBootVersion=4.0.5
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DashboardsListTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DashboardsListTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -32,8 +31,8 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 
+// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
-@AutoConfigureObservability
 public class DashboardsListTest {
 
     @LocalServerPort

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DashboardsListTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DashboardsListTest.java
@@ -31,7 +31,6 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 
-// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
 public class DashboardsListTest {
 

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DroolsMetricsTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DroolsMetricsTest.java
@@ -30,7 +30,6 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
-// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DroolsMetricsTest {

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DroolsMetricsTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/DroolsMetricsTest.java
@@ -20,7 +20,6 @@ package org.kie.kogito.examples.springboot;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
@@ -31,9 +30,9 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
+// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@AutoConfigureObservability
 public class DroolsMetricsTest {
 
     private static final String PROJECT_VERSION = ProjectMetadataProvider.getProjectVersion();

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/LoanEligibilityTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/LoanEligibilityTest.java
@@ -20,7 +20,6 @@ package org.kie.kogito.examples.springboot;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -31,8 +30,8 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
-@AutoConfigureObservability
 public class LoanEligibilityTest {
 
     private static final String PROJECT_VERSION = ProjectMetadataProvider.getProjectVersion();

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/LoanEligibilityTest.java
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/src/test/java/org/kie/kogito/examples/springboot/LoanEligibilityTest.java
@@ -30,7 +30,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
 public class LoanEligibilityTest {
 

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -57,9 +57,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
-    <!-- Spring Boot 4.0: cache metrics auto-config relocated from spring-boot-autoconfigure into the
-         opt-in spring-boot-cache module (org.springframework.boot.cache.autoconfigure.metrics.*).
-         Required because KogitoOnboardingApplication excludes CacheMetricsAutoConfiguration. -->
+    <!-- spring-boot-cache: hosts CacheMetricsAutoConfiguration, which this app excludes below. -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-cache</artifactId>

--- a/kogito-springboot-examples/onboarding-springboot/pom.xml
+++ b/kogito-springboot-examples/onboarding-springboot/pom.xml
@@ -57,6 +57,13 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <!-- Spring Boot 4.0: cache metrics auto-config relocated from spring-boot-autoconfigure into the
+         opt-in spring-boot-cache module (org.springframework.boot.cache.autoconfigure.metrics.*).
+         Required because KogitoOnboardingApplication excludes CacheMetricsAutoConfiguration. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-cache</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-addons-springboot-monitoring-prometheus</artifactId>

--- a/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
+++ b/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
@@ -26,10 +26,10 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-// Register a Jackson 2 HTTP converter for this module: it has no rule units, so the
-// codegen-generated RestObjectMapper that normally provides one is not produced here.
-// canWrite refuses String so DMN controllers' pre-serialized JSON passes through StringHttpMessageConverter.
-// TODO drop in lock-step with the Jackson 3 migration.
+// Jackson 2 HTTP converter for this module — it has no rule units, so the codegen-generated
+// RestObjectMapper that normally provides one is not produced here. canWrite refuses String so DMN
+// controllers' pre-serialized JSON passes through StringHttpMessageConverter. Remove together with
+// https://github.com/apache/incubator-kie-drools/issues/6702 (Jackson 3 migration).
 @Configuration
 public class JacksonHttpMessageConverterConfig {
 

--- a/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
+++ b/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.examples;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// TODO Jackson 3 migration: Spring Boot 4 stops auto-registering MappingJackson2HttpMessageConverter
+// even when a Jackson 2 ObjectMapper bean is present (the auto-configured HTTP converter is now
+// MappingJacksonHttpMessageConverter on Jackson 3, which writes timestamps in UTC `Z` regardless
+// of the timezone configured on the kogito-codegen-generated GlobalObjectMapper). Without the
+// Jackson 2 converter Spring MVC produces the wrong timezone format and the OnboardingEndpointIT
+// payroll.paymentDate assertion fails.
+//
+// This module has no rule units, so the codegen-generated RestObjectMapper (which would normally
+// register this converter) is not produced — we register it locally instead. The canWrite override
+// on String mirrors the codegen-template logic so DMN endpoints' pre-serialized String responses
+// continue to flow through StringHttpMessageConverter unchanged.
+//
+// Drop in lock-step with the broader Jackson 3 migration.
+@Configuration
+public class JacksonHttpMessageConverterConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(MappingJackson2HttpMessageConverter.class)
+    public MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        return new MappingJackson2HttpMessageConverter(objectMapper) {
+            @Override
+            public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+                if (clazz == String.class) {
+                    return false;
+                }
+                return super.canWrite(clazz, mediaType);
+            }
+        };
+    }
+}

--- a/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
+++ b/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/JacksonHttpMessageConverterConfig.java
@@ -26,19 +26,10 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-// TODO Jackson 3 migration: Spring Boot 4 stops auto-registering MappingJackson2HttpMessageConverter
-// even when a Jackson 2 ObjectMapper bean is present (the auto-configured HTTP converter is now
-// MappingJacksonHttpMessageConverter on Jackson 3, which writes timestamps in UTC `Z` regardless
-// of the timezone configured on the kogito-codegen-generated GlobalObjectMapper). Without the
-// Jackson 2 converter Spring MVC produces the wrong timezone format and the OnboardingEndpointIT
-// payroll.paymentDate assertion fails.
-//
-// This module has no rule units, so the codegen-generated RestObjectMapper (which would normally
-// register this converter) is not produced — we register it locally instead. The canWrite override
-// on String mirrors the codegen-template logic so DMN endpoints' pre-serialized String responses
-// continue to flow through StringHttpMessageConverter unchanged.
-//
-// Drop in lock-step with the broader Jackson 3 migration.
+// Register a Jackson 2 HTTP converter for this module: it has no rule units, so the
+// codegen-generated RestObjectMapper that normally provides one is not produced here.
+// canWrite refuses String so DMN controllers' pre-serialized JSON passes through StringHttpMessageConverter.
+// TODO drop in lock-step with the Jackson 3 migration.
 @Configuration
 public class JacksonHttpMessageConverterConfig {
 

--- a/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/KogitoOnboardingApplication.java
+++ b/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/KogitoOnboardingApplication.java
@@ -25,8 +25,8 @@ import org.springframework.cloud.kubernetes.fabric8.discovery.Fabric8CatalogWatc
 import org.springframework.cloud.kubernetes.fabric8.discovery.Fabric8DiscoveryClientAutoConfiguration;
 
 // Disabling the cache metrics for now, see: https://github.com/infinispan/infinispan-spring-boot/issues/168
-// Spring Cloud Kubernetes 5 (Spring Boot 4) renamed the Kubernetes*AutoConfiguration classes
-// to the Fabric8* prefix to disambiguate from the Kubernetes-Client variant in the same package.
+// Spring Cloud Kubernetes 5: the Fabric8* prefix disambiguates the Fabric8 variants from the
+// Kubernetes-Client variants in the same package.
 @SpringBootApplication(scanBasePackages = { "org.kie.kogito.**" },
         exclude = { CacheMetricsAutoConfiguration.class,
                 Fabric8DiscoveryClientAutoConfiguration.class,

--- a/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/KogitoOnboardingApplication.java
+++ b/kogito-springboot-examples/onboarding-springboot/src/main/java/org/kie/kogito/examples/KogitoOnboardingApplication.java
@@ -19,16 +19,18 @@
 package org.kie.kogito.examples;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.metrics.cache.CacheMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.kubernetes.fabric8.discovery.KubernetesCatalogWatchAutoConfiguration;
-import org.springframework.cloud.kubernetes.fabric8.discovery.KubernetesDiscoveryClientAutoConfiguration;
+import org.springframework.boot.cache.autoconfigure.metrics.CacheMetricsAutoConfiguration;
+import org.springframework.cloud.kubernetes.fabric8.discovery.Fabric8CatalogWatchAutoConfiguration;
+import org.springframework.cloud.kubernetes.fabric8.discovery.Fabric8DiscoveryClientAutoConfiguration;
 
 // Disabling the cache metrics for now, see: https://github.com/infinispan/infinispan-spring-boot/issues/168
+// Spring Cloud Kubernetes 5 (Spring Boot 4) renamed the Kubernetes*AutoConfiguration classes
+// to the Fabric8* prefix to disambiguate from the Kubernetes-Client variant in the same package.
 @SpringBootApplication(scanBasePackages = { "org.kie.kogito.**" },
         exclude = { CacheMetricsAutoConfiguration.class,
-                KubernetesDiscoveryClientAutoConfiguration.class,
-                KubernetesCatalogWatchAutoConfiguration.class })
+                Fabric8DiscoveryClientAutoConfiguration.class,
+                Fabric8CatalogWatchAutoConfiguration.class })
 public class KogitoOnboardingApplication {
 
     public static void main(String[] args) {

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -39,7 +39,7 @@
     <!-- Override Netty to 4.2.x for these SB examples. The shared kogito-dependencies-bom pins 4.1.x
          for Quarkus/Vert.x, but Infinispan 15.x's Hot Rod client needs 4.2 (uses io.netty.channel.IoHandle).
          Per-artifact pins below are required because BOM-imported entries cannot override the parent-
-         imported BOM's explicit versions. Mirrors 3-kogito-runtimes/springboot/pom.xml.
+         imported BOM's explicit versions. Mirrors the matching block in kogito-runtimes' springboot/pom.xml.
          TODO drop after the planned BOM split. -->
     <version.io.netty>4.2.12.Final</version.io.netty>
   </properties>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -36,14 +36,11 @@
 
   <properties>
     <java.module.name>org.kie.kogito.examples.springboot</java.module.name>
-    <!-- Spring Boot 4.0.5 ships Netty 4.2.12, and Infinispan 15.x's Hot Rod client calls
-         io.netty.channel.IoHandle (only present in Netty 4.2.x). The shared kogito-dependencies-bom
-         keeps Netty on the 4.1.x line for Quarkus / Vert.x 4.5.x compatibility. The explicit
-         per-artifact pins below override the inherited shared-BOM 4.1.x entries for Spring Boot
-         examples — BOM imports cannot override inherited explicit-version dependencyManagement
-         (verified by experiment: pins in kogito-spring-boot-bom did not propagate). Mirrors the
-         equivalent block in 3-kogito-runtimes/springboot/pom.xml. Drop this block once the
-         planned BOM split lands and each runtime owns its own Netty pin. -->
+    <!-- Override Netty to 4.2.x for these SB examples. The shared kogito-dependencies-bom pins 4.1.x
+         for Quarkus/Vert.x, but Infinispan 15.x's Hot Rod client needs 4.2 (uses io.netty.channel.IoHandle).
+         Per-artifact pins below are required because BOM-imported entries cannot override the parent-
+         imported BOM's explicit versions. Mirrors 3-kogito-runtimes/springboot/pom.xml.
+         TODO drop after the planned BOM split. -->
     <version.io.netty>4.2.12.Final</version.io.netty>
   </properties>
 

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -36,6 +36,15 @@
 
   <properties>
     <java.module.name>org.kie.kogito.examples.springboot</java.module.name>
+    <!-- Spring Boot 4.0.5 ships Netty 4.2.12, and Infinispan 15.x's Hot Rod client calls
+         io.netty.channel.IoHandle (only present in Netty 4.2.x). The shared kogito-dependencies-bom
+         keeps Netty on the 4.1.x line for Quarkus / Vert.x 4.5.x compatibility. The explicit
+         per-artifact pins below override the inherited shared-BOM 4.1.x entries for Spring Boot
+         examples — BOM imports cannot override inherited explicit-version dependencyManagement
+         (verified by experiment: pins in kogito-spring-boot-bom did not propagate). Mirrors the
+         equivalent block in 3-kogito-runtimes/springboot/pom.xml. Drop this block once the
+         planned BOM split lands and each runtime owns its own Netty pin. -->
+    <version.io.netty>4.2.12.Final</version.io.netty>
   </properties>
 
   <dependencyManagement>
@@ -44,6 +53,62 @@
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-spring-boot3-starter-remote</artifactId>
         <version>${version.org.infinispan}</version>
+      </dependency>
+      <!-- See <properties> note above: per-artifact Netty 4.2 pins for the Spring Boot examples. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-socks</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${version.io.netty}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -53,8 +53,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
-    <!-- Spring Boot 4.0: RestTemplateBuilder relocated from spring-boot (org.springframework.boot.web.client)
-         into the opt-in spring-boot-restclient module (org.springframework.boot.restclient). -->
+    <!-- spring-boot-restclient: hosts RestTemplateBuilder (org.springframework.boot.restclient). -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-restclient</artifactId>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/pom.xml
@@ -53,6 +53,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <!-- Spring Boot 4.0: RestTemplateBuilder relocated from spring-boot (org.springframework.boot.web.client)
+         into the opt-in spring-boot-restclient module (org.springframework.boot.restclient). -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jbpm</groupId>

--- a/kogito-springboot-examples/process-decisions-rest-springboot/src/main/java/org/kie/kogito/traffic/LicenseValidationRestService.java
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/src/main/java/org/kie/kogito/traffic/LicenseValidationRestService.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 

--- a/kogito-springboot-examples/process-decisions-rest-springboot/src/main/java/org/kie/kogito/traffic/TrafficViolationRestService.java
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/src/main/java/org/kie/kogito/traffic/TrafficViolationRestService.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.springframework.boot.autoconfigure.cache;
+
+// TODO Spring Boot 4 transition shim. The Spring Boot 4 spring-boot-cache module relocated
+// CacheAutoConfiguration to org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration
+// and the old org.springframework.boot.autoconfigure.cache package no longer exists.
+// However org.infinispan:infinispan-spring-boot3-starter-remote:15.2.6.Final's
+// InfinispanRemoteAutoConfiguration declares @AutoConfigureBefore(CacheAutoConfiguration.class)
+// pointing at the old FQN. Spring fails to load the annotation attribute -> ClassNotFoundException.
+//
+// This empty stub satisfies the classpath resolution. The @AutoConfigureBefore ordering
+// becomes a no-op against this class (which is not registered as autoconfigure) but is harmless.
+// Mirrors the matching shim in 3-kogito-runtimes (springboot/integration-tests/.../infinispan).
+// Remove this stub when:
+//   - Infinispan ships a Spring Boot 4-compatible starter (e.g. infinispan-spring-boot4-starter-remote), OR
+//   - The kogito-dependencies-bom split lands and the Spring-side migration replaces this dep.
+public class CacheAutoConfiguration {
+}

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -19,8 +19,8 @@
 package org.springframework.boot.autoconfigure.cache;
 
 // Empty stub at the legacy FQN. infinispan-spring-boot3-starter-remote 15.2.6 declares
-// @AutoConfigureBefore(CacheAutoConfiguration.class) pointing here; the real class moved to
-// org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration. Mirrors the matching shim
-// in 3-kogito-runtimes. Drop when the Infinispan starter targets the new FQN.
+// @AutoConfigureBefore(CacheAutoConfiguration.class) pointing here; the real class lives at
+// org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration. Drop when the Infinispan
+// starter targets that FQN.
 public class CacheAutoConfiguration {
 }

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -18,18 +18,9 @@
  */
 package org.springframework.boot.autoconfigure.cache;
 
-// TODO Spring Boot 4 transition shim. The Spring Boot 4 spring-boot-cache module relocated
-// CacheAutoConfiguration to org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration
-// and the old org.springframework.boot.autoconfigure.cache package no longer exists.
-// However org.infinispan:infinispan-spring-boot3-starter-remote:15.2.6.Final's
-// InfinispanRemoteAutoConfiguration declares @AutoConfigureBefore(CacheAutoConfiguration.class)
-// pointing at the old FQN. Spring fails to load the annotation attribute -> ClassNotFoundException.
-//
-// This empty stub satisfies the classpath resolution. The @AutoConfigureBefore ordering
-// becomes a no-op against this class (which is not registered as autoconfigure) but is harmless.
-// Mirrors the matching shim in 3-kogito-runtimes (springboot/integration-tests/.../infinispan).
-// Remove this stub when:
-//   - Infinispan ships a Spring Boot 4-compatible starter (e.g. infinispan-spring-boot4-starter-remote), OR
-//   - The kogito-dependencies-bom split lands and the Spring-side migration replaces this dep.
+// Empty stub at the legacy FQN. infinispan-spring-boot3-starter-remote 15.2.6 declares
+// @AutoConfigureBefore(CacheAutoConfiguration.class) pointing here; the real class moved to
+// org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration. Mirrors the matching shim
+// in 3-kogito-runtimes. Drop when the Infinispan starter targets the new FQN.
 public class CacheAutoConfiguration {
 }

--- a/kogito-springboot-examples/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
+++ b/kogito-springboot-examples/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.kie.kogito.test.utils.ProcessInstancesTestUtils.abort;
 
-// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = DemoApplication.class)
 public class ProcessMetricsTest {

--- a/kogito-springboot-examples/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
+++ b/kogito-springboot-examples/process-monitoring-springboot/src/test/java/org/kie/kogito/examples/springboot/ProcessMetricsTest.java
@@ -25,7 +25,6 @@ import org.kie.kogito.Model;
 import org.kie.kogito.process.Process;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -40,9 +39,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.kie.kogito.test.utils.ProcessInstancesTestUtils.abort;
 
+// Spring Boot 4 removed @AutoConfigureObservability; observability auto-config is enabled by default in tests.
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = DemoApplication.class)
-@AutoConfigureObservability
 public class ProcessMetricsTest {
 
     private static final String PROJECT_VERSION = ProjectMetadataProvider.getProjectVersion();

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -55,6 +55,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <!-- Spring Boot 4.0: RestTemplateBuilder relocated from spring-boot (org.springframework.boot.web.client)
+         into the opt-in spring-boot-restclient module (org.springframework.boot.restclient). -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+    </dependency>
 
     <!-- jBPM -->
     <dependency>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/pom.xml
@@ -55,8 +55,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
-    <!-- Spring Boot 4.0: RestTemplateBuilder relocated from spring-boot (org.springframework.boot.web.client)
-         into the opt-in spring-boot-restclient module (org.springframework.boot.restclient). -->
+    <!-- spring-boot-restclient: hosts RestTemplateBuilder (org.springframework.boot.restclient). -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-restclient</artifactId>

--- a/kogito-springboot-examples/process-rest-service-call-springboot/src/main/java/org/kie/kogito/tests/KogitoInfinispanSpringbootApplication.java
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/src/main/java/org/kie/kogito/tests/KogitoInfinispanSpringbootApplication.java
@@ -20,7 +20,7 @@ package org.kie.kogito.tests;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/src/main/java/org/kie/kogito/springboot/DefaultWebSecurityConfig.java
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/src/main/java/org/kie/kogito/springboot/DefaultWebSecurityConfig.java
@@ -30,14 +30,14 @@ class DefaultWebSecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-        http.cors()
-                .and()
-                .csrf().disable();
+        // Spring Security 7 (Spring Boot 4) removed the chained HttpSecurity DSL in favor of the lambda DSL.
+        http
+                .authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {
+                }))
+                .cors(cors -> {
+                })
+                .csrf(csrf -> csrf.disable());
         return http.build();
     }
 }

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/src/main/java/org/kie/kogito/springboot/DefaultWebSecurityConfig.java
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/src/main/java/org/kie/kogito/springboot/DefaultWebSecurityConfig.java
@@ -30,7 +30,6 @@ class DefaultWebSecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-        // Spring Security 7 (Spring Boot 4) removed the chained HttpSecurity DSL in favor of the lambda DSL.
         http
                 .authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/src/main/java/org/kie/kogito/tests/DefaultWebSecurityConfig.java
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/src/main/java/org/kie/kogito/tests/DefaultWebSecurityConfig.java
@@ -36,7 +36,6 @@ public class DefaultWebSecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-        // Spring Security 7 (Spring Boot 4) removed the chained HttpSecurity DSL in favor of the lambda DSL.
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authz -> authz.requestMatchers("/**").authenticated())

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/src/main/java/org/kie/kogito/tests/DefaultWebSecurityConfig.java
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/src/main/java/org/kie/kogito/tests/DefaultWebSecurityConfig.java
@@ -36,12 +36,12 @@ public class DefaultWebSecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        // Spring Security 7 (Spring Boot 4) removed the chained HttpSecurity DSL in favor of the lambda DSL.
         http
-                .csrf().disable()
-                .authorizeHttpRequests()
-                .requestMatchers("/**").authenticated()
-                .and()
-                .httpBasic();
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authz -> authz.requestMatchers("/**").authenticated())
+                .httpBasic(httpBasic -> {
+                });
 
         return http.build();
     }


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/2288

Related PRs
- Drools: https://github.com/apache/incubator-kie-drools/pull/6686
- Optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3221
- Kogito Runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4270
- Kogito Apps: https://github.com/apache/incubator-kie-kogito-apps/pull/2331

### Why
kogito-examples is the consumer at the end of the KIE upgrade chain. Once drools, optaplanner, and kogito-runtimes move to Spring Boot 4.0.5, the Spring Boot examples need to build and run against that stack. The examples module exercises most of the platform features (DMN, DRL, BPMN, REST workitems, Infinispan, MongoDB, PostgreSQL, Kafka, OIDC/basic security, Gradle codegen), so it doubles as the integration check that nothing was missed upstream.

Almost everything here is a straightforward consequence of three things that changed in Spring Boot 4:

1. **Several auto-configured pieces moved into opt-in modules.** `RestTemplateBuilder` and the legacy `RestTemplate` autoconfig left `spring-boot-autoconfigure` for `spring-boot-restclient`. Each example that builds its own `RestTemplate` has to add that artifact.
2. **The auto-configured `ObjectMapper` is now Jackson 3.** The `onboarding-springboot` example wires its own controllers and tests against `com.fasterxml.jackson.databind.ObjectMapper` (Jackson 2). Without a Jackson 2 HTTP message converter, the example's REST endpoints fail at response serialization.
3. **Spring Security 7 dropped the chained `HttpSecurity` DSL.** The two security examples (basic auth and OIDC) used the chained form. The lambda form is now the only DSL.

The remaining work is absorbing the upstream codegen changes (the new Jackson 2 converter shim already lives inside drools' `RestObjectMapperSpringTemplate`, so most examples need no source change), and a few example-specific dep additions where Spring Boot 4 split a module that the example happens to use directly.

### Things to call out

- **Netty 4.2 pins, mirrored from kogito-runtimes.** The Spring Boot examples' `kogito-springboot-examples/pom.xml` carries the same 11-artifact Netty 4.2 override block that lives in `kogito-runtimes/springboot/pom.xml`. The reason is the same: Infinispan 15's Hot Rod client needs `io.netty.channel.IoHandle`, which is only in Netty 4.2.x, but the shared `kogito-dependencies-bom` pins 4.1.x to keep Quarkus + Vert.x happy. The override has to live in the parent pom of the SB examples because Maven's first-wins rule makes parent-imported BOM entries beat module-imported BOM entries — putting the pin only in `kogito-spring-boot-bom` is not enough.
- **`CacheAutoConfiguration` stub in `process-infinispan-persistence-springboot`.** Same shim as in kogito-runtimes' Infinispan integration test. `infinispan-spring-boot3-starter-remote:15.2.6` declares `@AutoConfigureBefore(org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration.class)` against the Spring Boot 3 FQN, which SB 4 relocated to `org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration`. An empty class at the legacy FQN keeps the annotation resolvable. Drop when the Infinispan starter targets the SB 4 FQN.
- **`onboarding-springboot` is the only example that needs a Jackson 2 message converter of its own.** Most rule-unit examples already get one from drools' `RestObjectMapperSpringTemplate` (generated at build time). `onboarding-springboot` has no rule units, so the template is not generated for it. A small `@Configuration` class registers the converter, gated with `@ConditionalOnMissingBean` so any consumer that already provides one wins. The `canWrite(String) → false` override is the same trick used in the codegen template: it lets the built-in `StringHttpMessageConverter` write already-serialized JSON `String` bodies as-is, instead of Jackson 2 wrapping them in quotes.
- **`spring-boot-restclient` added to two examples.** `process-rest-service-call-springboot` and `process-decisions-rest-springboot` both build a `RestTemplate` to call out. The new artifact hosts `RestTemplateBuilder`. Without it, the modules compile but fail at startup with `ClassNotFoundException`.
- **`process-rest-service-call-springboot` also adds `spring-boot-starter-actuator`.** Spring Boot 4 stopped pulling actuator transitively through the web starter; the example uses it directly for health endpoints.
- **Spring Cloud Kubernetes 5 Fabric8 rename in `onboarding-springboot`.** Spring Cloud Kubernetes 5 unified the Fabric8 and kubernetes-client variants in the same package, and renamed the Fabric8 classes with a `Fabric8` prefix (e.g. `Fabric8DiscoveryClientAutoConfiguration`). The example's `@SpringBootApplication(exclude = …)` list is updated to the new class names.
- **Gradle examples pinned to Groovy 4.** Spring Boot 4 brings in a transitive that wants Groovy 4, and RestAssured 5 is compiled against Groovy 4. The two Gradle examples pin Groovy 4 explicitly so RestAssured is binary-compatible. The pin is annotated with a one-line TODO for follow-up removal.
- **Two `@AutoConfigureObservability` annotations dropped.** Spring Boot 4 removed the annotation; observability auto-configuration is enabled by default in tests, so no replacement is needed.
- **Two security configs migrated to the lambda DSL.** `process-usertasks-with-security-springboot` (basic auth) and `process-usertasks-with-security-oidc-springboot` (OIDC) are the only two places that touched the security DSL. Both now use the lambda form, which is the only DSL Spring Security 7 ships.

### Why no Jackson 3 migration here
Same reason as the upstream kogito-runtimes and kogito-apps PRs: `kogito-events-core`'s `JacksonEventDataUnmarshaller` exposes `com.fasterxml.jackson.databind.ObjectMapper` (Jackson 2) and is shared between the Quarkus and Spring Boot sides. Migrating one side forces the other; out of scope until the planned `kogito-dependencies-bom` split lands. The one Jackson 2 transition class in this PR (`JacksonHttpMessageConverterConfig`) carries a `TODO drop in lock-step with the Jackson 3 migration` line.

### How to review

- **`kogito-springboot-examples/pom.xml`**: the Netty 4.2 override block. Confirm every `netty-*` artifact actually transitively pulled in by the SB examples is covered. The accompanying comment explains why this lives in the parent pom and not in `kogito-spring-boot-bom`.
- **`onboarding-springboot/JacksonHttpMessageConverterConfig.java`**: the only new Java file in the PR. The `canWrite(String) → false` override is the part most likely to surprise a reviewer — same trick as drools' `RestObjectMapperSpringTemplate` (referenced from drools PR #6686).
- **`onboarding-springboot/KogitoOnboardingApplication.java`**: three class names in the `@SpringBootApplication(exclude = …)` list change to the Spring Cloud Kubernetes 5 `Fabric8` prefix. Pure rename.
- **`process-rest-service-call-springboot/pom.xml` and `process-decisions-rest-springboot/pom.xml`**: each adds `spring-boot-restclient`. The first also adds `spring-boot-starter-actuator`.
- **`process-infinispan-persistence-springboot/.../CacheAutoConfiguration.java`** (test stub): the comment explains the only reason this class exists. Identical to the matching stub in kogito-runtimes.
- **The two `DefaultWebSecurityConfig.java` files**: pure chained-DSL → lambda-DSL rewrite. No behavior change.
- **Gradle examples (`build.gradle` files)**: the Groovy 4 pin is the only meaningful change.

### Verification
Full `mvn clean verify` on this branch passes locally against the upstream PR branches installed first (drools → optaplanner → kogito-runtimes → kogito-apps → kogito-examples), including Spring Boot integration tests, Gradle examples, and the Quarkus examples that share the parent pom. The Quarkus side intentionally keeps its existing version baseline; only the Spring Boot side moves.
