### PR TITLE
[kie-issues#2306] Update Spring dependencies to 6.2.18 and Spring Boot to 3.5.14

### DIFF
--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=3.5.12
+springBootVersion=3.5.14
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=3.5.12
+springBootVersion=3.5.14
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1


### PR DESCRIPTION
New vulnerabilities have been identified in Spring Boot and the Spring Framework. To address these issues, the following dependency updates are required:
Changes
Spring Boot: 3.5.12 → 3.5.14
These updates include fixes for the latest reported security vulnerabilities.

Related PR:
https://github.com/apache/incubator-kie-optaplanner/pull/3222
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4282
https://github.com/apache/incubator-kie-tools/pull/3574
