### PR TITLE
[CVE][Critical] CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 spring-boot-4.0.5.jar

### DIFF
--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=4.0.5
+springBootVersion=4.0.6
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=4.0.5
+springBootVersion=4.0.6
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -39,7 +39,7 @@
     <allowedPomsList>org.kie.kogito.examples:kogito-springboot-examples</allowedPomsList>
     <java.module.name>org.kie.kogito.examples.springboot</java.module.name>
     <!-- TODO: remove the following properties and declare  kogito-apps-springboot-bom as parent, to have everything already inherited-->
-    <version.org.springframework.boot>4.0.5</version.org.springframework.boot>
+    <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
     <!-- This is needed to avoid having a different version of netty inherited by kogito-examples. -->
     <version.io.netty>4.2.12.Final</version.io.netty>
   </properties>


### PR DESCRIPTION
## Summary
Bumps the managed **Spring Boot version from 4.0.5 → 4.0.6** in kogito-examples.
Because no Spring Security version is pinned, this also pulls **Spring Security
7.0.4 → 7.0.5** transitively via `spring-boot-dependencies`, remediating the
Spring Boot and Spring Security CVEs flagged in this repo.

## CVEs remediated
| Package | CVEs |
|---------|------|
| spring-boot | CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 |
| spring-boot-autoconfigure | CVE-2026-40974, CVE-2026-40971 |
| spring-boot-security | CVE-2026-40976 |
| spring-security-oauth2-jose | CVE-2026-22748 |
| spring-security-web | CVE-2026-22747 |
| spring-security-config | CVE-2026-22754, CVE-2026-22753 |
| spring-security-core | CVE-2026-22751, CVE-2026-22746 |

## Changes
- `kogito-springboot-examples/pom.xml` — `version.org.springframework.boot` 4.0.5 → 4.0.6
- `gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties` — `springBootVersion` 4.0.5 → 4.0.6
- `gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties` — `springBootVersion` 4.0.5 → 4.0.6

## Connected PRs
- optaplanner — https://github.com/apache/incubator-kie-optaplanner/pull/3232
- kogito-runtimes — https://github.com/apache/incubator-kie-kogito-runtimes/pull/4309
- kie-tools — https://github.com/apache/incubator-kie-tools/pull/3618
