### PR TITLE
Spring boot Patch version upgrade to 4.0.7

### DIFF
--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=4.0.6
+springBootVersion=4.0.7
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
+++ b/gradle-examples/kogito-springboot-gradle-examples/process-decisions-rules-springboot-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-springBootVersion=4.0.6
+springBootVersion=4.0.7
 springBootDependencyManagementVersion=1.1.5
 taskTreeVersion=4.0.1
 junitVersion=5.12.1

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -39,7 +39,7 @@
     <allowedPomsList>org.kie.kogito.examples:kogito-springboot-examples</allowedPomsList>
     <java.module.name>org.kie.kogito.examples.springboot</java.module.name>
     <!-- TODO: remove the following properties and declare  kogito-apps-springboot-bom as parent, to have everything already inherited-->
-    <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
+    <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
     <!-- This is needed to avoid having a different version of netty inherited by kogito-examples. -->
     <version.io.netty>4.2.12.Final</version.io.netty>
   </properties>


### PR DESCRIPTION
Spring boot version upgrade to fix below CVEs



| Dependency | Critical | High | Medium | Low |
|------------|----------|------|--------|-----|
| spring-web (7.0.7) | - | CVE-2026-41845 | CVE-2026-41839, CVE-2026-41840, CVE-2026-41853, CVE-2026-41854 | - |
| spring-webmvc (7.0.7) | - | CVE-2026-41842 | CVE-2026-41841, CVE-2026-41843, CVE-2026-41844, CVE-2026-41846 | - |
| spring-core (7.0.7) | - | - | - | CVE-2026-41848 |
| spring-expression (7.0.7) | - | CVE-2026-41850 | CVE-2026-41851 | CVE-2026-41852 |
| spring-security-core (7.0.5) | - | CVE-2026-40988 | CVE-2026-41008 | CVE-2026-41694 |
| spring-security-web (7.0.5) | - | - | CVE-2026-41706 | - |
| spring-kafka (4.0.5) | - | CVE-2026-41731 | CVE-2026-41726, CVE-2026-41727 | - |
| spring-data-mongodb (5.0.5) | - | CVE-2026-41717 | CVE-2026-41696 | - |
| spring-data-commons (4.0.5) | - | CVE-2026-41695, CVE-2026-41716 | CVE-2026-41711, CVE-2026-41721 | - |

Optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3234
Runtimes : https://github.com/apache/incubator-kie-kogito-runtimes/pull/4317
Kie-Tools: https://github.com/apache/incubator-kie-tools/pull/3631
