### PR TITLE
NO-ISSUE:Upgrade Quarkus from 3.27.4.1 to 3.27.5.1 , Netty 4.2.15.Final to 4.2.16.final

### DIFF
--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-## 3.27.4.1 needed to support gradle 9.2
+## 3.27.5.1 needed to support gradle 9.2
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=3.27.5.1
 quarkusPlatformGroupId=io.quarkus.platform

--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
@@ -1,10 +1,10 @@
 #Gradle properties
 ## 3.27.4.1 needed to support gradle 9.2
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.27.4.1
+quarkusPluginVersion=3.27.5.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.27.4.1
+quarkusPlatformVersion=3.27.5.1
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-## 3.27.4.1 needed to support gradle 9.2
+## 3.27.5.1 needed to support gradle 9.2
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=3.27.5.1
 quarkusPlatformGroupId=io.quarkus.platform

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
@@ -1,10 +1,10 @@
 #Gradle properties
 ## 3.27.4.1 needed to support gradle 9.2
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.27.4.1
+quarkusPluginVersion=3.27.5.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.27.4.1
+quarkusPlatformVersion=3.27.5.1
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>decisiontable-quarkus-example</artifactId>
   <name>Kogito Example :: Decision Table - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>dmn-15-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: 1.5 Features</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-drools-quarkus-metrics</artifactId>
   <name>Kogito Example :: DMN Metrics Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -32,10 +32,10 @@
   <artifactId>dmn-event-driven-quarkus</artifactId>
   <name>Kogito Example :: DMN Event-Driven :: Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: DMN Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -33,10 +33,10 @@
   <description>Kogito with DMN Knative Eventing - Quarkus</description>
 
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-listener-dtable</artifactId>
   <name>Kogito Example :: DMN Decision Table listener - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-listener-quarkus</artifactId>
   <name>Kogito Example :: DMN with listeners - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-multiple-models-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: Multiple Models</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-pmml-quarkus-example</artifactId>
   <name>Kogito Example :: DMN :: PMML - QUARKUS</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-quarkus-example</artifactId>
   <name>Kogito Example :: DMN</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
@@ -12,10 +12,10 @@
   <artifactId>dmn-quarkus-consumer-example</artifactId>
 
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: DMN :: Resource jar providing model</name>
 
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>dmn-tracing-quarkus</artifactId>
   <name>Kogito Example :: DMN Tracing - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>flexible-process-quarkus</artifactId>
   <name>Kogito Example :: Flexible Process - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -32,10 +32,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/pom.xml
@@ -35,10 +35,10 @@
     <module>visas</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>travels</artifactId>
   <name>Kogito Example :: Travel Agency :: Travels</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>visas</artifactId>
   <name>Kogito Example :: Travel Agency :: Visas</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/kogito-travel-agency/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/pom.xml
@@ -35,10 +35,10 @@
     <module>extended</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Onboarding Example :: Payroll with DMN</name>
   <description>Payroll related decisions for onboarding</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-quarkus-examples/onboarding-example/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/pom.xml
@@ -37,10 +37,10 @@
     <module>onboarding-quarkus</module>
   </modules>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>pmml-event-driven-quarkus</artifactId>
   <name>Kogito Example :: PMML Event-Driven - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>pmml-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: PMML Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>pmml-quarkus-example</artifactId>
   <name>Kogito Example :: PMML - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
@@ -34,10 +34,10 @@
     <name>Kogito Example :: Process Business Calendar</name>
     
     <properties>
-        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.3</quarkus.platform.version>
+        <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
         <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Business Rules Quarkus</name>
   <description>Kogito business rules invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process :: Decisions :: Quarkus</name>
   <description>Process with DMN and DRL integration - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -32,10 +32,10 @@
   <description>Process with DMN and DRL integration through REST - Quarkus</description>
   <properties>
     <tests.quarkus.http.port>8080</tests.quarkus.http.port>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
@@ -31,7 +31,7 @@
   <name>Kogito Example :: Process :: Decisions :: Rules :: Quarkus :: YaML</name>
   <description>Process with DRL, DMN and DRL integration - Quarkus - YaML Configuration</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>3.27.2</quarkus.platform.version>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
@@ -34,7 +34,7 @@
     <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.2</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process :: Decisions :: Rules :: Quarkus</name>
   <description>Process with DRL, DMN and DRL integration - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -30,10 +30,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>process-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Process Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Infinispan Persistence Quarkus</name>
   <description>Process with Infinispan persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-instance-migration-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Instance Migration Quarkus</name>
   <description>Process Instance Migration example - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-quarkus-bom</kogito.bom.artifact-id>
     <kogito-apps.bom.artifact-id>kogito-apps-quarkus-bom</kogito-apps.bom.artifact-id>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels, avro serialization</name>
   <description>Kogito with Kafka - Quarkus, using one channel per message name</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus, multiple channels</name>
   <description>Kogito with Kafka - Quarkus, using one channel per message name</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -33,10 +33,10 @@
   <name>Kogito Example :: Process Kafka Persistence Quarkus</name>
   <description>Process with Kafka persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process with Kafka and Quarkus</name>
   <description>Kogito with Kafka - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process with Knative Eventing and Quarkus</name>
   <description>Kogito with Knative Eventing - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process MongoDB Persistence Quarkus</name>
   <description>Process with MongoDB persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Monitoring :: Quarkus</name>
 
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-outbox-mongodb-quarkus/pom.xml
@@ -35,10 +35,10 @@
 
   <properties>
     <DEBEZIUM_VERSION>1.7</DEBEZIUM_VERSION>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-performance-client/pom.xml
+++ b/kogito-quarkus-examples/process-performance-client/pom.xml
@@ -33,10 +33,10 @@
   <name>Kogito Example :: Client Performance test</name>
   <description>Client Performance test</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-performance-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-performance-quarkus/pom.xml
@@ -33,10 +33,10 @@
   <name>Kogito Example :: Quarkus Performance test</name>
   <description>Quarkus Performance test</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -36,10 +36,10 @@
   <name>Kogito Example :: Process PostgreSQL Persistence Quarkus</name>
   <description>Process with PostgreSQL persistence - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process and Quarkus</name>
   <description>Order management service</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Service Rest Cal with Quarkus</name>
   <description>Kogito service invocation using REST - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Rest :: Quarkus</name>
   <description>Invoking multiple Rest WS using RestWorkItemHandler</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Service Rest WorkItem call with Quarkus</name>
   <description>Kogito service invocation using REST work item and Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -33,10 +33,10 @@
   <description>How to implement Saga with a BPMN Process using Compensations</description>
 
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Scripts With Quarkus</name>
   <description>Kogito scripts invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Service Calls with Quarkus</name>
   <description>Kogito service invocation - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-timer-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Timer with Quarkus</name>
   <description>Kogito with timers - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -33,10 +33,10 @@
    <name>Kogito Example :: Process Usertasks With Custom Lifecycle</name>
    <description>Kogito user tasks orchestration with custom life cycle - Quarkus</description>
    <properties>
-      <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+      <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-      <quarkus.platform.version>3.27.3</quarkus.platform.version>
+      <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
       <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
       <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
       <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process with Usertasks Quarkus</name>
   <description>Kogito user tasks orchestration - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>process-usertasks-timer-quarkus</artifactId>
   <name>Kogito Example :: Process UserTasks with Timer Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Usertasks With Security OIDC Keycloak Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - open id connect adapter(keycloak)</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: Process Usertasks With Security Quarkus</name>
   <description>Kogito user tasks orchestration with security enabled on REST api - Quarkus</description>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-ws-humantask-lifecycle-quarkus/pom.xml
@@ -34,10 +34,10 @@
     <description>Kogito user tasks orchestration with Web Service HumanTask life cycle - Quarkus</description>
 
     <properties>
-        <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+        <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.3</quarkus.platform.version>
+        <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
         <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
         <kogito.bom.artifact-id>kogito-quarkus-bom</kogito.bom.artifact-id>
         <kogito-apps.bom.artifact-id>kogito-apps-quarkus-bom</kogito-apps.bom.artifact-id>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>rules-incubation-api-quarkus</artifactId>
   <name>Kogito Example :: Rules Incubation API With Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>rules-legacy-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API - Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>rules-legacy-scesim-quarkus-example</artifactId>
   <name>Kogito Example :: Rules Legacy API HELLO - Quarkus :: Test Scenario</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>rules-quarkus-helloworld</artifactId>
   <name>Kogito Example :: Rules HelloWorld</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -32,10 +32,10 @@
   <artifactId>ruleunit-event-driven-quarkus</artifactId>
   <name>Kogito Example :: Rule Unit Event-Driven :: Quarkus</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -31,10 +31,10 @@
   <name>Kogito Example :: RuleUnit - Quarkus</name>
   
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/pom.xml
@@ -30,10 +30,10 @@
   <artifactId>trusty-tracing-quarkus-devservices</artifactId>
   <name>Kogito Example :: Trusty Tracing - Quarkus DevServices</name>
   <properties>
-    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus-plugin.version>3.27.5.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.27.5.1</quarkus.platform.version>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>

--- a/kogito-springboot-examples/pom.xml
+++ b/kogito-springboot-examples/pom.xml
@@ -41,7 +41,7 @@
     <!-- TODO: remove the following properties and declare  kogito-apps-springboot-bom as parent, to have everything already inherited-->
     <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
     <!-- This is needed to avoid having a different version of netty inherited by kogito-examples. -->
-    <version.io.netty>4.2.12.Final</version.io.netty>
+    <version.io.netty>4.2.16.Final</version.io.netty>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Summary

Upgrades Quarkus from `3.27.4.1` → `3.27.5.1` across all affected modules to remediate two CVEs.

## Fix Strategy

- **CVE-2026-55831 (netty 4.1.x):** Quarkus 3.27.5.1 BOM pins `io.netty:netty-codec-http:4.1.136.Final` — resolves automatically via upgrade.
- **CVE-2026-55831 (netty 4.2.x):** Direct property `version.io.netty` bumped `4.2.15.Final` → `4.2.16.Final` in `springboot/bom/pom.xml` (Spring Boot path, independent of Quarkus BOM).
- **CVE-2026-8484 (jansi):** Quarkus 3.27.5 upgraded `readline` from `2.6` → `2.6.3`, which replaces the unmaintained `org.fusesource.jansi:jansi:2.4.0` with the maintained `org.jline:jansi:4.2.1`. No separate exclusion needed.

## Verification

Confirmed via `quarkus-bom 3.27.5.1` dependency management on Maven Central:
- `org.aesh:readline` = `2.6.3` → `org.jline:jansi` = `4.2.1`

## Related PRs
-https://github.com/apache/incubator-kie-tools/pull/3700
-https://github.com/apache/incubator-kie/pull/6882
