### PR TITLE
[NO-ISSUE]: chore: upgrade Maven from 3.9.11 to 3.9.16

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/README.md
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/README.md
@@ -11,7 +11,7 @@ The org.kie.dmn.runtime.typecheck=true property is used to enable type and value
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
 
 ## Build and run

--- a/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/README.md
+++ b/gradle-examples/kogito-springboot-gradle-examples/dmn-springboot-gradle/README.md
@@ -11,7 +11,7 @@ The org.kie.dmn.runtime.typecheck=true property is used to enable type and value
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
 
 ## Build and run

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/README.md
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/README.md
@@ -17,7 +17,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 21.0.2](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.2) installed

--- a/kogito-quarkus-examples/dmn-15-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-15-quarkus-example/README.md
@@ -94,7 +94,7 @@ This example also features the `org.kie.dmn.runtime.typecheck` environment varia
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/README.md
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/README.md
@@ -9,7 +9,7 @@ This example demonstrates how to enable and consume the runtime metrics monitori
 You will need:
   - Java 17+ installed 
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
   
 ### How to enable the feature

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito DMN services to be used as par
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 When using native image compilation, you will also need:

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/README.md
@@ -19,7 +19,7 @@ The custom REST endpoint evaluates a DMN that computes Traffic Violation:
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/README.md
@@ -28,7 +28,7 @@ You will need:
 
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
 

--- a/kogito-quarkus-examples/dmn-listener-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/README.md
@@ -15,7 +15,7 @@ Listener injection is _optional_. If you don't need it, just ignore it.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/README.md
@@ -13,7 +13,7 @@ Demonstrates DMN on Kogito capabilities, including REST interface code generatio
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/README.md
@@ -13,7 +13,7 @@ Demonstrates DMN on Kogito capabilities, including REST interface code generatio
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/dmn-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-quarkus-example/README.md
@@ -15,7 +15,7 @@ Demonstrates DMN on Kogito capabilities, including REST interface code generatio
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/README.md
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/README.md
@@ -14,7 +14,7 @@ Demonstrates DMN on Kogito capabilities, including REST interface code generatio
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/README.md
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/README.md
@@ -11,7 +11,7 @@ A simple DMN service to evaluate a loan approval and generate tracing events tha
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/flexible-process-quarkus/README.md
+++ b/kogito-quarkus-examples/flexible-process-quarkus/README.md
@@ -45,7 +45,7 @@ You will need:
 
 * Java 17+ installed
 * Environment variable JAVA_HOME set accordingly
-* Maven 3.9.11+ installed
+* Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
 

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/README.md
@@ -101,7 +101,7 @@ You will need:
 
 * Java 17+ installed
 * Environment variable JAVA_HOME set accordingly
-* Maven 3.9.11+ installed
+* Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
 

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/README.md
@@ -115,7 +115,7 @@ There will be services implemented to carry on the hotel and flight booking. Imp
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3.1+ installed

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/README.md
@@ -61,7 +61,7 @@ Public process that will be responsible for processing visa application
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3.1+ installed

--- a/kogito-quarkus-examples/onboarding-example/README.md
+++ b/kogito-quarkus-examples/onboarding-example/README.md
@@ -29,7 +29,7 @@ You will need:
 
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
 

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito PMML services to be used as pa
 You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 When using native image compilation, you will also need:

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/README.md
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/README.md
@@ -19,7 +19,7 @@ The custom REST endpoint evaluates a PMML that computes a linear regression:
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/pmml-quarkus-example/README.md
+++ b/kogito-quarkus-examples/pmml-quarkus-example/README.md
@@ -13,7 +13,7 @@ Demonstrates PMML on Kogito capabilities, including REST interface code generati
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   
 When using native image compilation, you will also need:
   - [GraalVM 19.3.1](https://github.com/oracle/graal/releases/tag/vm-19.3.1) installed

--- a/kogito-quarkus-examples/process-business-calendar-quarkus-example/README.md
+++ b/kogito-quarkus-examples/process-business-calendar-quarkus-example/README.md
@@ -67,7 +67,7 @@ The final step where the payment is settled successfully on manual verification.
 You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/process-business-rules-quarkus/README.md
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/README.md
@@ -56,7 +56,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-decisions-quarkus/README.md
+++ b/kogito-quarkus-examples/process-decisions-quarkus/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/README.md
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/README.md
@@ -147,7 +147,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/README.md
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus/README.md
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-error-handling/README.md
+++ b/kogito-quarkus-examples/process-error-handling/README.md
@@ -60,7 +60,7 @@ The `Apply` script calls the corresponding method of the class `ErrorHandlingScr
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/README.md
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/README.md
@@ -18,7 +18,7 @@ The custom REST endpoint evaluates a process that expects a name:
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/README.md
@@ -74,7 +74,7 @@ You can install Infinispan server by downloading version 12.x from the [official
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/README.md
@@ -90,7 +90,7 @@ https://kafka.apache.org/quickstart
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/README.md
@@ -80,7 +80,7 @@ https://kafka.apache.org/quickstart
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/README.md
@@ -76,7 +76,7 @@ docker compose up
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 20.2+ installed

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/README.md
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/README.md
@@ -80,7 +80,7 @@ https://kafka.apache.org/quickstart
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/README.md
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/README.md
@@ -80,7 +80,7 @@ You will need:
 
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
 

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/README.md
@@ -73,7 +73,7 @@ For more details you can check applications.properties.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-monitoring-quarkus/README.md
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/README.md
@@ -10,7 +10,7 @@ You will need:
 
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
 
 ### How to enable the feature

--- a/kogito-quarkus-examples/process-performance-quarkus/README.md
+++ b/kogito-quarkus-examples/process-performance-quarkus/README.md
@@ -20,7 +20,7 @@ Kafka cluster installed and available over the network. Refer to [Kafka Apache s
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - Apache Kafka 
 
 When using native image compilation, you will also need:

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/README.md
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/README.md
@@ -85,7 +85,7 @@ Optionally and for convenience, a docker-compose [configuration file](docker-com
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-quarkus-example/README.md
+++ b/kogito-quarkus-examples/process-quarkus-example/README.md
@@ -15,7 +15,7 @@ Based on these two processes (defined using BPMN 2.0 format), the custom data ob
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.1.1](https://github.com/oracle/graal/releases/tag/vm-19.1.1) installed

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/README.md
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/README.md
@@ -50,7 +50,7 @@ during REST service invocation.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.1+ installed

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/README.md
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/README.md
@@ -19,7 +19,7 @@ and returns the sum.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need: 
   - [GraalVm](https://www.graalvm.org/downloads/) 20.2.0+ installed

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/README.md
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/README.md
@@ -54,7 +54,7 @@ during REST service invocation.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.1+ installed

--- a/kogito-quarkus-examples/process-saga-quarkus/README.md
+++ b/kogito-quarkus-examples/process-saga-quarkus/README.md
@@ -45,7 +45,7 @@ This is the BPMN process that represents the Order Saga, and it is the one being
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.1.1](https://github.com/oracle/graal/releases/tag/vm-19.1.1) installed

--- a/kogito-quarkus-examples/process-scripts-quarkus/README.md
+++ b/kogito-quarkus-examples/process-scripts-quarkus/README.md
@@ -30,7 +30,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-service-calls-quarkus/README.md
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/README.md
@@ -67,7 +67,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.1+ installed

--- a/kogito-quarkus-examples/process-timer-quarkus/README.md
+++ b/kogito-quarkus-examples/process-timer-quarkus/README.md
@@ -86,7 +86,7 @@ This needs to be given when starting process instance as delay attribute of type
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/README.md
@@ -56,7 +56,7 @@ To learn more about custom lifecycle, look at the following classes:
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-usertasks-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/README.md
@@ -44,7 +44,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need: 
   - GraalVM 19.3+ installed

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/README.md
@@ -22,7 +22,7 @@ The required *Kogito and Infrastructure Services* for this example are:
 
 * Java 17+ installed
 * Environment variable JAVA_HOME set accordingly
-* Maven 3.9.11+ installed
+* Maven 3.9.16+ installed
 * Docker and Docker Compose to run the required example infrastructure.
 
 And when using native image compilation, you will also need: 

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/README.md
@@ -24,7 +24,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [jq](https://stedolan.github.io/jq) tool installed. You can download it from [here](https://stedolan.github.io/jq/download)
   - Docker
 

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/README.md
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/README.md
@@ -24,7 +24,7 @@ This example shows
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - GraalVM 19.1+ installed

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/README.md
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/README.md
@@ -19,7 +19,7 @@ The custom REST endpoint evaluates a rule unit that returns a hello world messag
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/README.md
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/README.md
@@ -13,7 +13,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 21.0.2](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.2) installed

--- a/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/README.md
+++ b/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/README.md
@@ -31,7 +31,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 21.0.2](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.2) installed

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/README.md
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/README.md
@@ -11,7 +11,7 @@ A minimal hello world rule service.
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.1.1](https://github.com/oracle/graal/releases/tag/vm-19.1.1) installed

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/README.md
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito DRL services to be used as par
 You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 When using native image compilation, you will also need:

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/README.md
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/README.md
@@ -13,7 +13,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 When using native image compilation, you will also need:
   - [GraalVM 19.2.1](https://github.com/oracle/graal/releases/tag/vm-19.2.1) installed

--- a/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/README.md
+++ b/kogito-quarkus-examples/trusty-tracing-quarkus-devservices/README.md
@@ -12,7 +12,7 @@ PostgreSQL instance and a User Interface can be launched from Quarkus DevMode to
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - A Docker environment
 
 ### Compile and Run in Local Dev Mode

--- a/kogito-springboot-examples/decisiontable-springboot-example/README.md
+++ b/kogito-springboot-examples/decisiontable-springboot-example/README.md
@@ -17,7 +17,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/decisiontable-springboot-example/README.md
+++ b/kogito-springboot-examples/decisiontable-springboot-example/README.md
@@ -15,7 +15,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/dmn-15-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-15-springboot-example/README.md
@@ -94,7 +94,7 @@ This example also features the `org.kie.dmn.runtime.typecheck` environment varia
 You will need:
   - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
@@ -9,7 +9,7 @@ This example demonstrates how to enable and consume the runtime metrics monitori
 You will need:
   - Java 11+ installed 
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).
 
 ### How to enable the feature

--- a/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
+++ b/kogito-springboot-examples/dmn-drools-springboot-metrics/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to enable and consume the runtime metrics monitori
 ### Prerequisites
  
 You will need:
-  - Java 11+ installed 
+  - Java 17+ installed 
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker compose` script provided in this example).

--- a/kogito-springboot-examples/dmn-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito DMN services to be used as par
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 ### Enable The AddOn

--- a/kogito-springboot-examples/dmn-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/dmn-event-driven-springboot/README.md
@@ -14,7 +14,7 @@ The main goal behind the addon is to allow Kogito DMN services to be used as par
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed

--- a/kogito-springboot-examples/dmn-listener-springboot/README.md
+++ b/kogito-springboot-examples/dmn-listener-springboot/README.md
@@ -13,7 +13,7 @@ Listener injection is _optional_. If you don't need it, just ignore it.
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/dmn-listener-springboot/README.md
+++ b/kogito-springboot-examples/dmn-listener-springboot/README.md
@@ -15,7 +15,7 @@ Listener injection is _optional_. If you don't need it, just ignore it.
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/README.md
@@ -9,7 +9,7 @@ A simple DMN + PMML service.
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/dmn-pmml-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-pmml-springboot-example/README.md
@@ -11,7 +11,7 @@ A simple DMN + PMML service.
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/dmn-resource-jar-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-resource-jar-springboot-example/README.md
@@ -14,7 +14,7 @@ Demonstrates DMN on Kogito capabilities, including REST interface code generatio
 You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/dmn-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-springboot-example/README.md
@@ -11,7 +11,7 @@ The org.kie.dmn.runtime.typecheck=true property is used to enable type and value
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/dmn-springboot-example/README.md
+++ b/kogito-springboot-examples/dmn-springboot-example/README.md
@@ -13,7 +13,7 @@ The org.kie.dmn.runtime.typecheck=true property is used to enable type and value
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/dmn-tracing-springboot/README.md
+++ b/kogito-springboot-examples/dmn-tracing-springboot/README.md
@@ -11,7 +11,7 @@ A simple DMN service to evaluate a loan approval and generate tracing events tha
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Configuration of the tracing addon
 

--- a/kogito-springboot-examples/dmn-tracing-springboot/README.md
+++ b/kogito-springboot-examples/dmn-tracing-springboot/README.md
@@ -9,7 +9,7 @@ A simple DMN service to evaluate a loan approval and generate tracing events tha
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/flexible-process-springboot/README.md
+++ b/kogito-springboot-examples/flexible-process-springboot/README.md
@@ -45,7 +45,7 @@ You will need:
 
 * Java 11+ installed
 * Environment variable JAVA_HOME set accordingly
-* Maven 3.9.11+ installed
+* Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/flexible-process-springboot/README.md
+++ b/kogito-springboot-examples/flexible-process-springboot/README.md
@@ -43,7 +43,7 @@ will terminate.
 
 You will need:
 
-* Java 11+ installed
+* Java 17+ installed
 * Environment variable JAVA_HOME set accordingly
 * Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/onboarding-springboot/README.md
+++ b/kogito-springboot-examples/onboarding-springboot/README.md
@@ -30,7 +30,7 @@ You will need:
 
 - Java 11+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 ### Installation
 

--- a/kogito-springboot-examples/onboarding-springboot/README.md
+++ b/kogito-springboot-examples/onboarding-springboot/README.md
@@ -28,7 +28,7 @@ interaction with HR and payroll.
 
 You will need:
 
-- Java 11+ installed
+- Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
 - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/pmml-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito PMML services to be used as pa
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 ### Enable The AddOn

--- a/kogito-springboot-examples/pmml-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/pmml-event-driven-springboot/README.md
@@ -14,7 +14,7 @@ The main goal behind the addon is to allow Kogito PMML services to be used as pa
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed

--- a/kogito-springboot-examples/pmml-springboot-example/README.md
+++ b/kogito-springboot-examples/pmml-springboot-example/README.md
@@ -11,7 +11,7 @@ A simple PMML service.
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/pmml-springboot-example/README.md
+++ b/kogito-springboot-examples/pmml-springboot-example/README.md
@@ -9,7 +9,7 @@ A simple PMML service.
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-business-calendar-springboot-example/README.md
+++ b/kogito-springboot-examples/process-business-calendar-springboot-example/README.md
@@ -67,7 +67,7 @@ The final step where the payment is settled successfully on manual verification.
 You will need:
 - Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-business-rules-springboot/README.md
+++ b/kogito-springboot-examples/process-business-rules-springboot/README.md
@@ -54,7 +54,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-business-rules-springboot/README.md
+++ b/kogito-springboot-examples/process-business-rules-springboot/README.md
@@ -56,7 +56,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-decisions-rest-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/README.md
@@ -147,7 +147,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-decisions-rest-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-rest-springboot/README.md
@@ -145,7 +145,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-decisions-rules-springboot-yaml/README.md
+++ b/kogito-springboot-examples/process-decisions-rules-springboot-yaml/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-decisions-rules-springboot-yaml/README.md
+++ b/kogito-springboot-examples/process-decisions-rules-springboot-yaml/README.md
@@ -111,7 +111,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-decisions-rules-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-rules-springboot/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-decisions-rules-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-rules-springboot/README.md
@@ -111,7 +111,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-decisions-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-springboot/README.md
@@ -113,7 +113,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-decisions-springboot/README.md
+++ b/kogito-springboot-examples/process-decisions-springboot/README.md
@@ -111,7 +111,7 @@ The DMN file where this decision is declared is [TrafficViolation.dmn](src/main/
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/README.md
@@ -72,7 +72,7 @@ You can install Infinispan server by downloading version 12.x from the [official
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-infinispan-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-infinispan-persistence-springboot/README.md
@@ -70,7 +70,7 @@ You can install Infinispan server by downloading version 12.x from the [official
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-kafka-multi-springboot/README.md
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/README.md
@@ -77,7 +77,7 @@ https://kafka.apache.org/quickstart
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-kafka-multi-springboot/README.md
+++ b/kogito-springboot-examples/process-kafka-multi-springboot/README.md
@@ -79,7 +79,7 @@ https://kafka.apache.org/quickstart
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/README.md
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/README.md
@@ -78,7 +78,7 @@ https://kafka.apache.org/quickstart
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-kafka-quickstart-springboot/README.md
+++ b/kogito-springboot-examples/process-kafka-quickstart-springboot/README.md
@@ -80,7 +80,7 @@ https://kafka.apache.org/quickstart
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/README.md
@@ -73,7 +73,7 @@ For more details you can check applications.properties.
 You will need:
   - Java 11+ installed 
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Enable MongoDB configuration
 

--- a/kogito-springboot-examples/process-mongodb-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-mongodb-persistence-springboot/README.md
@@ -71,7 +71,7 @@ For more details you can check applications.properties.
 ### Prerequisites
  
 You will need:
-  - Java 11+ installed 
+  - Java 17+ installed 
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-monitoring-springboot/README.md
+++ b/kogito-springboot-examples/process-monitoring-springboot/README.md
@@ -10,7 +10,7 @@ You will need:
 
 - Java 11+ installed
 - Environment variable JAVA_HOME set accordingly
-- Maven 3.9.11+ installed
+- Maven 3.9.16+ installed
 - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker-compose` script provided in this example).
 
 ### How to enable the feature

--- a/kogito-springboot-examples/process-monitoring-springboot/README.md
+++ b/kogito-springboot-examples/process-monitoring-springboot/README.md
@@ -8,7 +8,7 @@ This example demonstrates how to enable and consume the runtime metrics monitori
 
 You will need:
 
-- Java 11+ installed
+- Java 17+ installed
 - Environment variable JAVA_HOME set accordingly
 - Maven 3.9.16+ installed
 - Docker 19+ (only if you want to run the integration tests and/or you want to use the `docker-compose` script provided in this example).

--- a/kogito-springboot-examples/process-performance-springboot/README.md
+++ b/kogito-springboot-examples/process-performance-springboot/README.md
@@ -24,7 +24,7 @@ Kafka cluster installed and available over the network. Refer to [Kafka Apache s
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - Apache Kafka
 
 ### Compile and Run in Local Dev Mode

--- a/kogito-springboot-examples/process-performance-springboot/README.md
+++ b/kogito-springboot-examples/process-performance-springboot/README.md
@@ -22,7 +22,7 @@ Kafka cluster installed and available over the network. Refer to [Kafka Apache s
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - Apache Kafka

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
@@ -85,7 +85,7 @@ Optionally and for convenience, a docker-compose [configuration file](docker-com
 You will need:
   - Java 11+ installed 
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
+++ b/kogito-springboot-examples/process-postgresql-persistence-springboot/README.md
@@ -83,7 +83,7 @@ Optionally and for convenience, a docker-compose [configuration file](docker-com
 ### Prerequisites
  
 You will need:
-  - Java 11+ installed 
+  - Java 17+ installed 
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-rest-service-call-springboot/README.md
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/README.md
@@ -45,7 +45,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-rest-service-call-springboot/README.md
+++ b/kogito-springboot-examples/process-rest-service-call-springboot/README.md
@@ -47,7 +47,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-scripts-springboot/README.md
+++ b/kogito-springboot-examples/process-scripts-springboot/README.md
@@ -30,7 +30,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-scripts-springboot/README.md
+++ b/kogito-springboot-examples/process-scripts-springboot/README.md
@@ -28,7 +28,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-service-calls-springboot/README.md
+++ b/kogito-springboot-examples/process-service-calls-springboot/README.md
@@ -65,7 +65,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-service-calls-springboot/README.md
+++ b/kogito-springboot-examples/process-service-calls-springboot/README.md
@@ -67,7 +67,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-springboot-example/README.md
+++ b/kogito-springboot-examples/process-springboot-example/README.md
@@ -13,7 +13,7 @@ Based on these two processes (defined using BPMN 2.0 format), the custom data ob
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-springboot-example/README.md
+++ b/kogito-springboot-examples/process-springboot-example/README.md
@@ -15,7 +15,7 @@ Based on these two processes (defined using BPMN 2.0 format), the custom data ob
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-timer-springboot/README.md
+++ b/kogito-springboot-examples/process-timer-springboot/README.md
@@ -86,7 +86,7 @@ This needs to be given when starting process instance as delay attribute of type
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-timer-springboot/README.md
+++ b/kogito-springboot-examples/process-timer-springboot/README.md
@@ -84,7 +84,7 @@ This needs to be given when starting process instance as delay attribute of type
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/README.md
@@ -56,7 +56,7 @@ To learn more about custom lifecycle, look at the following classes:
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-custom-lifecycle-springboot/README.md
@@ -54,7 +54,7 @@ To learn more about custom lifecycle, look at the following classes:
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-usertasks-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-springboot/README.md
@@ -42,7 +42,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-usertasks-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-springboot/README.md
@@ -44,7 +44,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/README.md
@@ -24,7 +24,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [jq](https://stedolan.github.io/jq) tool installed. You can download it from [here](https://stedolan.github.io/jq/download)
   - Docker to be able to install keycloak server
 

--- a/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-with-security-oidc-springboot/README.md
@@ -22,7 +22,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - [jq](https://stedolan.github.io/jq) tool installed. You can download it from [here](https://stedolan.github.io/jq/download)

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/README.md
@@ -22,7 +22,7 @@ This example shows
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/process-usertasks-with-security-springboot/README.md
+++ b/kogito-springboot-examples/process-usertasks-with-security-springboot/README.md
@@ -24,7 +24,7 @@ This example shows
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run in Local Dev Mode
 

--- a/kogito-springboot-examples/rules-legacy-scesim-springboot-example/README.md
+++ b/kogito-springboot-examples/rules-legacy-scesim-springboot-example/README.md
@@ -29,7 +29,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/rules-legacy-scesim-springboot-example/README.md
+++ b/kogito-springboot-examples/rules-legacy-scesim-springboot-example/README.md
@@ -31,7 +31,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/rules-legacy-springboot-example/README.md
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/README.md
@@ -11,7 +11,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 

--- a/kogito-springboot-examples/rules-legacy-springboot-example/README.md
+++ b/kogito-springboot-examples/rules-legacy-springboot-example/README.md
@@ -13,7 +13,7 @@ An injectable KieRuntimeBuilder is generated, so you can create Drools v7 KieBas
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
@@ -16,7 +16,7 @@ The main goal behind the addon is to allow Kogito DRL services to be used as par
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed
 
 ### Enable The AddOn

--- a/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
+++ b/kogito-springboot-examples/ruleunit-event-driven-springboot/README.md
@@ -14,7 +14,7 @@ The main goal behind the addon is to allow Kogito DRL services to be used as par
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
   - [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed

--- a/kogito-springboot-examples/ruleunit-springboot-example/README.md
+++ b/kogito-springboot-examples/ruleunit-springboot-example/README.md
@@ -13,7 +13,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 You will need:
   - Java 11+ installed
   - Environment variable JAVA_HOME set accordingly
-  - Maven 3.9.11+ installed
+  - Maven 3.9.16+ installed
 
 ### Compile and Run
 

--- a/kogito-springboot-examples/ruleunit-springboot-example/README.md
+++ b/kogito-springboot-examples/ruleunit-springboot-example/README.md
@@ -11,7 +11,7 @@ REST endpoints are generated from query rules. You can insert `LoanApplication` 
 ### Prerequisites
 
 You will need:
-  - Java 11+ installed
+  - Java 17+ installed
   - Environment variable JAVA_HOME set accordingly
   - Maven 3.9.16+ installed
 


### PR DESCRIPTION
- Update Maven Wrapper distributionUrl to apache-maven-3.9.16
- Update Maven version prerequisite in all example README files (97 README files across kogito-quarkus-examples and kogito-springboot-examples)
