### PR TITLE
[incubator-kie-6902] Upgrade Quarkus to 3.33.3.2 (LTS)- #3987

### DIFF
--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
@@ -1,10 +1,11 @@
 #Gradle properties
-## 3.27.5.1 needed to support gradle 9.2
+## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
+## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.27.5.1
+quarkusPluginVersion=3.33.3.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.27.5.1
+quarkusPlatformVersion=3.33.3.1
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
@@ -1,6 +1,4 @@
 #Gradle properties
-## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
-## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=3.33.3.2
 quarkusPlatformGroupId=io.quarkus.platform

--- a/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/dmn-quarkus-gradle/gradle.properties
@@ -2,10 +2,10 @@
 ## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
 ## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.33.3.1
+quarkusPluginVersion=3.33.3.2
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.33.3.1
+quarkusPlatformVersion=3.33.3.2
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
@@ -1,10 +1,11 @@
 #Gradle properties
-## 3.27.5.1 needed to support gradle 9.2
+## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
+## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.27.5.1
+quarkusPluginVersion=3.33.3.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.27.5.1
+quarkusPlatformVersion=3.33.3.1
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
@@ -1,6 +1,4 @@
 #Gradle properties
-## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
-## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=3.33.3.2
 quarkusPlatformGroupId=io.quarkus.platform

--- a/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
+++ b/gradle-examples/kogito-quarkus-gradle-examples/process-decisions-rules-quarkus-gradle/gradle.properties
@@ -2,10 +2,10 @@
 ## Quarkus 3.27+ is required for Gradle 9.2 support (wrapper: 9.2.1). Gradle cannot inherit from the
 ## Maven parent, so this pin is maintained by hand and must track the kie stack (version.io.quarkus).
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.33.3.1
+quarkusPluginVersion=3.33.3.2
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.33.3.1
+quarkusPlatformVersion=3.33.3.2
 taskTreeVersion=4.0.1
 junitVersion=5.12.1
 kogitoVersion=999-SNAPSHOT

--- a/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/decisiontable-quarkus-example/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-15-quarkus-example/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
+++ b/kogito-quarkus-examples/dmn-drools-quarkus-metrics/pom.xml
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-event-driven-quarkus/pom.xml
@@ -84,7 +84,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-incubation-api-quarkus/pom.xml
@@ -66,7 +66,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-knative-quickstart-quarkus/pom.xml
@@ -86,7 +86,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-dtable/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-listener-quarkus/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-multiple-models-quarkus-example/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-pmml-quarkus-example/pom.xml
@@ -150,7 +150,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-quarkus-example/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
+++ b/kogito-quarkus-examples/dmn-resource-jar-quarkus-example/dmn-quarkus-consumer-example/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
+++ b/kogito-quarkus-examples/dmn-tracing-quarkus/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
+++ b/kogito-quarkus-examples/flexible-process-quarkus/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/basic/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/travels/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
+++ b/kogito-quarkus-examples/kogito-travel-agency/extended/visas/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/onboarding-example/hr/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/hr/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
+++ b/kogito-quarkus-examples/onboarding-example/payroll/pom.xml
@@ -71,7 +71,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-event-driven-quarkus/pom.xml
@@ -79,7 +79,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/pmml-incubation-api-quarkus/pom.xml
@@ -66,7 +66,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/pmml-quarkus-example/pom.xml
@@ -145,7 +145,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-business-calendar-quarkus-example/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-business-rules-quarkus/pom.xml
@@ -67,7 +67,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-quarkus/pom.xml
@@ -68,7 +68,7 @@
     <!--Tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rest-quarkus/pom.xml
@@ -89,7 +89,7 @@
     <!--Tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus-yaml/pom.xml
@@ -68,7 +68,7 @@
     <!--Tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-decisions-rules-quarkus/pom.xml
@@ -68,7 +68,7 @@
     <!--Tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-error-handling/pom.xml
+++ b/kogito-quarkus-examples/process-error-handling/pom.xml
@@ -66,7 +66,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-incubation-api-quarkus/pom.xml
@@ -66,7 +66,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-infinispan-persistence-quarkus/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-avro-multi-quarkus/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-multi-quarkus/pom.xml
@@ -76,7 +76,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-persistence-quarkus/pom.xml
@@ -77,7 +77,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-kafka-quickstart-quarkus/pom.xml
@@ -71,7 +71,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-knative-quickstart-quarkus/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-mongodb-persistence-quarkus/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-monitoring-quarkus/pom.xml
@@ -76,7 +76,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-postgresql-persistence-quarkus/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/process-quarkus-example/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-service-call-quarkus/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-multi-quarkus/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-rest-workitem-quarkus/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-saga-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-saga-quarkus/pom.xml
@@ -68,7 +68,7 @@
     <!-- Test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-scripts-quarkus/pom.xml
@@ -67,7 +67,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-service-calls-quarkus/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-custom-lifecycle-quarkus/pom.xml
@@ -96,7 +96,7 @@
       </dependency>
       <dependency>
          <groupId>io.quarkus</groupId>
-         <artifactId>quarkus-junit5</artifactId>
+         <artifactId>quarkus-junit</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-quarkus/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-timer-quarkus/pom.xml
@@ -97,7 +97,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-oidc-quarkus/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
+++ b/kogito-quarkus-examples/process-usertasks-with-security-quarkus/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
+++ b/kogito-quarkus-examples/rules-incubation-api-quarkus/pom.xml
@@ -66,7 +66,7 @@
     <!--tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-quarkus-example/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/rules-legacy-scesim-quarkus-example/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
+++ b/kogito-quarkus-examples/rules-quarkus-helloworld/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-event-driven-quarkus/pom.xml
@@ -80,7 +80,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
+++ b/kogito-quarkus-examples/ruleunit-quarkus-example/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,8 @@
     <!-- Reproducible builds -->
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
+    <!-- JKube -->
+    <version.org.eclipse.jkube>1.4.0</version.org.eclipse.jkube>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito.examples:kogito-examples</allowedPomsList>
   </properties>
@@ -151,6 +153,23 @@
           <configuration>
             <skip>true</skip>
           </configuration>
+        </plugin>
+        <!-- Kept pinned here for the Java and Gradle examples, which inherit from this pom: failsafe must
+             track surefire (${version.surefire.plugin}), and the JKube plugins must not resolve to LATEST. -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${version.surefire.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.jkube</groupId>
+          <artifactId>kubernetes-maven-plugin</artifactId>
+          <version>${version.org.eclipse.jkube}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.jkube</groupId>
+          <artifactId>openshift-maven-plugin</artifactId>
+          <version>${version.org.eclipse.jkube}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,6 @@
     <!-- Reproducible builds -->
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
-    <!-- JKube -->
-    <version.org.eclipse.jkube>1.4.0</version.org.eclipse.jkube>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito.examples:kogito-examples</allowedPomsList>
   </properties>
@@ -154,22 +152,12 @@
             <skip>true</skip>
           </configuration>
         </plugin>
-        <!-- Kept pinned here for the Java and Gradle examples, which inherit from this pom: failsafe must
-             track surefire (${version.surefire.plugin}), and the JKube plugins must not resolve to LATEST. -->
+        <!-- The Java and Gradle trees inherit from this pom and get no aggregator pluginManagement:
+             failsafe must track surefire, which the kie parent pins off a different property. -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.jkube</groupId>
-          <artifactId>kubernetes-maven-plugin</artifactId>
-          <version>${version.org.eclipse.jkube}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.jkube</groupId>
-          <artifactId>openshift-maven-plugin</artifactId>
-          <version>${version.org.eclipse.jkube}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
**Issue:** Closes https://github.com/apache/incubator-kie/issues/6902

**Related:** 
- https://github.com/apache/incubator-kie-examples/pull/2244 [MERGED]
- https://github.com/apache/incubator-kie/pull/6903  [MERGED]
- https://github.com/apache/incubator-kie-tools/pull/3987  [MERGED]


#2244 moved the shared build configuration out of the examples root pom into the Quarkus and Spring Boot
aggregators, so the Maven examples now inherit their platform versions from the kie BOMs. Two things it could not
cover are left:

1. **Gradle cannot inherit from a Maven parent.** The Gradle examples still declare the Quarkus version literally,
   and were still on 3.27.5.1.
2. **The root pom is the parent of the Java and Gradle trees only.** When the shared `pluginManagement` moved into
   the two aggregators, those trees lost pins they had been relying on.

## What changed

**`gradle-examples/kogito-quarkus-gradle-examples/{dmn-quarkus-gradle,process-decisions-rules-quarkus-gradle}/gradle.properties`**
- `quarkusPluginVersion` and `quarkusPlatformVersion` 3.27.5.1 → **3.33.3.2**, matching `version.io.quarkus` in the
  kie stack. The Spring Boot Gradle examples need no change: `springBootVersion` 4.0.7 already matches what
  `kogito-springboot/bom` declares.

**`pom.xml` (examples root)**
- restore `version.org.eclipse.jkube` 1.4.0 and `pluginManagement` entries for `kubernetes-maven-plugin`,
  `openshift-maven-plugin` and `maven-failsafe-plugin` (`${version.surefire.plugin}`).

## Why those pins matter

Measured by diffing the effective POM of all 81 modules against `main`, before restoring them:

- **`jkube` kubernetes/openshift-maven-plugin went from pinned 1.4.0 to *unversioned*** in 9 modules (the root
  aggregator, `kogito-java-examples`, and the Gradle trees) — precisely the "Maven resolves the latest release"
  hazard, which would make historical tags non-reproducible.
- **`maven-failsafe-plugin` silently dropped 3.3.1 → 3.2.5** in those same 9 modules, while `maven-surefire-plugin`
  stayed at 3.3.1 — leaving the two mismatched within one build.

After this PR the only plugin-version differences against `main` are intended:

| plugin | main → branch | modules |
|---|---|---|
| `quarkus-maven-plugin` | 3.27.5.1 → 3.33.3.2 | 63 (the upgrade itself) |
| `maven-resources-plugin` | 2.5 → 3.1.0 | 79 (the old root pom pinned a 2012 version) |
| `quarkus-extension-maven-plugin` | **unversioned** → 3.33.3.2 | 69 (a float removed) |
| `quarkus-maven-plugin` | **unversioned** → 3.33.3.2 | 6 (a float removed) |
| `kogito-maven-plugin` | **unversioned** → 999-SNAPSHOT | 1 (a float removed) |

## Verification

- `mvn validate` over the whole repository: **BUILD SUCCESS**, 81 modules, zero
  `'build.plugins.plugin.version' ... is missing` warnings, and the same **5** RELEASE-resolved core plugins as
  `main` — all of them in the parentless `kjar` examples under `kogito-java-examples`, which is pre-existing.
- Effective-POM comparison of all 81 modules against `main`, as tabulated above: no unintended version moved.
- Gradle: both examples build on the repository's Gradle **9.2.1** wrapper with Quarkus 3.33.3.2 —
  `gradlew clean test` → 8 tests, 0 failures, in each. `io.quarkus.platform:quarkus-bom:3.33.3.2` is on Maven
  Central and the 3.33.3.2 Gradle plugin resolves from plugins.gradle.org (not Central), so the existing
  `pluginManagement` repository entry in each `settings.gradle` remains load-bearing.
