### PR TITLE
chore(deps): upgrade Gradle wrapper to 9.7.1

### DIFF
--- a/gradle-examples/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
With Quarkus 3.33, Gradle 9.7.1 is suggested for new projects --> https://quarkus.io/guides/gradle-tooling/

- https://github.com/apache/incubator-kie/pull/7091
- https://github.com/apache/incubator-kie-examples/pull/2247