### PR TITLE
fix(onboarding-quarkus): disable HTTPS on KubernetesMockServer to fix flaky IT on JDK 17

### DIFF
--- a/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/src/test/java/org/kie/kogito/examples/onboarding/OnboardingEndpointIT.java
+++ b/kogito-quarkus-examples/onboarding-example/onboarding-quarkus/src/test/java/org/kie/kogito/examples/onboarding/OnboardingEndpointIT.java
@@ -43,7 +43,7 @@ import jakarta.inject.Inject;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.Is.is;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 @QuarkusTest
 @QuarkusTestResource(value = InfinispanQuarkusTestResource.Conditional.class)
 public class OnboardingEndpointIT {


### PR DESCRIPTION
## Problem

`OnboardingEndpointIT` fails intermittently in CI with:


```
io.vertx.core.VertxException: java.security.cert.CertificateException:
No provider succeeded to generate a self-signed certificate.
Caused by: java.lang.UnsupportedOperationException:
OpenJdkSelfSignedCertGenerator not supported on the used JDK version
```


The `@EnableKubernetesMockClient` annotation starts a `KubernetesMockServer`
in HTTPS mode by default. To serve TLS, Netty's `SelfSignedCertificate` tries
three certificate generators in sequence:

| Provider | Result on JDK 17 |
|---|---|
| `OpenJdkSelfSignedCertGenerator` | Always fails — `sun.security.x509.*` blocked by JPMS strong encapsulation |
| `BouncyCastleSelfSignedCertGenerator` | Always fails — BouncyCastle not on the classpath |
| `KeytoolSelfSignedCertGenerator` | Intermittently fails — shells out to `keytool`, sensitive to runner environment |

Because the first two providers are categorically broken on JDK 17, the entire
reliability burden falls on the `keytool` fallback, which is sensitive to PATH
propagation and ephemeral runner image changes — causing the non-systematic failure.

## Fix

Add `https = false` to the `@EnableKubernetesMockClient` annotation.

The mock server is only present so the `kie-addons-quarkus-kubernetes` extension
has a Kubernetes API endpoint to connect to at application startup. The test itself
exercises process execution over REST and has no dependency on the transport
protocol used by the mock server. HTTP is fully sufficient.